### PR TITLE
Fix GitHub auth header handling

### DIFF
--- a/app/api/onboard/route.ts
+++ b/app/api/onboard/route.ts
@@ -31,10 +31,13 @@ export async function POST(req: Request) {
       },
     };
 
-    const token = await getTokenForRepo(owner, repo);
+    const auth = await getTokenForRepo(owner, repo);
 
     await upsertFile({
-      owner, repo, branch, token,
+      owner,
+      repo,
+      branch,
+      auth,
       path: ".roadmaprc.json",
       json: roadmapRc,
     });

--- a/app/api/settings/route.ts
+++ b/app/api/settings/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getTokenForRepo } from "@/lib/token";
+import { getTokenForRepo, authHeaders } from "@/lib/token";
 import { openEditRcPR } from "@/lib/github-pr";
 
 export async function GET(req: NextRequest) {
@@ -7,9 +7,9 @@ export async function GET(req: NextRequest) {
   const repo  = req.nextUrl.searchParams.get('repo') || '';
   if (!owner || !repo) return NextResponse.json({ error: "missing params" }, { status: 400 });
 
-  const token = await getTokenForRepo(owner, repo);
+  const auth = await getTokenForRepo(owner, repo);
   const r = await fetch(`https://api.github.com/repos/${owner}/${repo}/contents/.roadmaprc.json`, {
-    headers: { Authorization: `Bearer ${token}`, Accept: "application/vnd.github.v3.raw" },
+    headers: authHeaders(auth, { Accept: "application/vnd.github.v3.raw" }),
     cache: "no-store"
   });
   if (!r.ok) return NextResponse.json({ error: `fetch rc failed: ${r.status}` }, { status: 500 });
@@ -21,8 +21,8 @@ export async function POST(req: NextRequest) {
   try {
     const { owner, repo, branch, content } = await req.json();
     if (!owner || !repo || !branch || !content) return NextResponse.json({ error: "missing fields" }, { status: 400 });
-    const token = await getTokenForRepo(owner, repo);
-    const pr = await openEditRcPR({ owner, repo, token, branch, newContent: content });
+    const auth = await getTokenForRepo(owner, repo);
+    const pr = await openEditRcPR({ owner, repo, auth, branch, newContent: content });
     return NextResponse.json({ url: pr.html_url || null, number: pr.number || null });
   } catch (e:any) {
     return NextResponse.json({ error: String(e?.message || e) }, { status: 500 });

--- a/app/api/setup/route.ts
+++ b/app/api/setup/route.ts
@@ -68,9 +68,9 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: e?.message || String(e) }, { status: 400 });
   }
 
-  // 3) Generate token & open PR with robust error surfacing
+  // 3) Generate GitHub credentials & open PR with robust error surfacing
   try {
-    const token = await getTokenForRepo(owner, repo);
+    const auth = await getTokenForRepo(owner, repo);
 
     const files = [
       {
@@ -140,7 +140,7 @@ export async function POST(req: NextRequest) {
     const pr = await openSetupPR({
       owner,
       repo,
-      token,
+      auth,
       branch, // e.g. "chore/roadmap-setup"
       files,
       title: "chore(setup): roadmap-kit bootstrap",

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { Suspense, useEffect, useMemo, useState } from "react";
 import { useSearchParams } from "next/navigation";
 
 type Check = {
@@ -236,7 +236,7 @@ function WeekCard({ week }: { week: Week }) {
   );
 }
 
-export default function Page() {
+function PageContent() {
   const sp = useSearchParams();
   const owner = sp.get("owner") || "SSkylar1";
   const repo = sp.get("repo") || "Roadmap-Kit-Starter";
@@ -289,6 +289,31 @@ export default function Page() {
         </div>
       )}
     </main>
+  );
+}
+
+function PageFallback() {
+  return (
+    <main className="mx-auto max-w-4xl p-4">
+      <h1 className="text-2xl font-bold">Roadmap Dashboard Pro</h1>
+      <p className="mt-1 text-sm text-gray-600">
+        Onboard repos, view status, edit rc, and verify infra — safely.
+      </p>
+
+      <div className="mt-3 h-5 w-40 animate-pulse rounded-full bg-gray-200" />
+
+      <div className="mt-6 animate-pulse rounded-2xl border p-6 text-gray-500">
+        Loading dashboard…
+      </div>
+    </main>
+  );
+}
+
+export default function Page() {
+  return (
+    <Suspense fallback={<PageFallback />}>
+      <PageContent />
+    </Suspense>
   );
 }
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -236,7 +236,7 @@ function WeekCard({ week }: { week: Week }) {
   );
 }
 
-function PageContent() {
+function DashboardPage() {
   const sp = useSearchParams();
   const owner = sp.get("owner") || "SSkylar1";
   const repo = sp.get("repo") || "Roadmap-Kit-Starter";
@@ -312,7 +312,7 @@ function PageFallback() {
 export default function Page() {
   return (
     <Suspense fallback={<PageFallback />}>
-      <PageContent />
+      <DashboardPage />
     </Suspense>
   );
 }

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -1,10 +1,22 @@
+import { RepoAuth, authHeaders } from "./token";
+
 export async function fetchRepoFile({
-  owner, repo, path, ref, token
-}: { owner: string; repo: string; path: string; ref?: string; token: string }) {
+  owner,
+  repo,
+  path,
+  ref,
+  auth,
+}: {
+  owner: string;
+  repo: string;
+  path: string;
+  ref?: string;
+  auth: RepoAuth;
+}) {
   const url = `https://api.github.com/repos/${owner}/${repo}/contents/${encodeURIComponent(path)}${ref ? `?ref=${ref}` : ""}`;
   const r = await fetch(url, {
-    headers: { Authorization: `Bearer ${token}`, Accept: "application/vnd.github.v3.raw" },
-    cache: "no-store"
+    headers: authHeaders(auth, { Accept: "application/vnd.github.v3.raw" }),
+    cache: "no-store",
   });
   if (!r.ok) return null;
   return await r.text();


### PR DESCRIPTION
## Summary
- return structured GitHub auth metadata and helpers so callers can build the right Authorization header
- update GitHub content/PR helpers and API routes to send the proper auth scheme for GitHub App tokens and PATs
- ensure onboarding/setup flows pass the new auth object when editing roadmap files

## Testing
- npx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68cf15f99640832d8768b4e4b6975c42