### PR TITLE
Add README status badge and expand adoption one-pager

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Roadmap Dashboard Pro
 
+[![Roadmap Checks](https://img.shields.io/github/actions/workflow/status/{{ORG}}/Roadmap-Kit-Starter/roadmap.yml?branch=main&label=roadmap)](https://github.com/{{ORG}}/Roadmap-Kit-Starter/actions/workflows/roadmap.yml)
+
+> Replace `{{ORG}}` with your GitHub organization (and the repo name if you renamed
+> the template) so the badge reflects your project’s live workflow status.
+
 Next.js dashboard for roadmap-kit projects with **GitHub App auth** (PAT fallback), a **Settings** page to edit `.roadmaprc.json` via PR, and basic **webhook** support.
 
 ## Quickstart (local)

--- a/docs/one-pager.md
+++ b/docs/one-pager.md
@@ -3,6 +3,12 @@
 **Goal:** equip a new initiative with the roadmap dashboard, automation, and docs in
 under half an hour.
 
+## TL;DR
+
+- Create a repo from the template and wire up credentials in minutes.
+- Run the roadmap checks so CI immediately reflects the new team’s setup.
+- Demo the dashboard and capture next steps before the half-hour is over.
+
 ## Who this is for
 
 - Engineering managers who need transparent roadmap execution.
@@ -15,16 +21,41 @@ under half an hour.
 - Reduces setup time from days to minutes by reusing the bootstrap template.
 - Keeps delivery predictable through automated checklist enforcement.
 
+## What you need before starting
+
+- GitHub permissions to create repositories inside the organization.
+- The roadmap-kit GitHub App (or a temporary PAT) ready for authentication.
+- Node.js 20+, npm, and the ability to run the verification script locally.
+- The Slack/Teams channel where you will share the dashboard link afterward.
+
 ## Step-by-step plan
 
+### 0–5 min — Create the space
+
 1. **Create the repo** using the bootstrap template (`Use this template → Create`).
-2. **Install dependencies** locally: `npm install` then copy `.env.example` to `.env.local`.
-3. **Configure credentials** with either the GitHub App (preferred) or a short-lived PAT.
-4. **Update `.roadmaprc.json`** with the correct `READ_ONLY_CHECKS_URL` for your Supabase Edge
-   function (or equivalent read-only verifier).
-5. **Edit `docs/roadmap.yml`** to reflect the actual initiatives and dependent files.
-6. **Run `npm run roadmap:check`** to validate files exist before pushing your first branch.
-7. **Open the dashboard** at `npm run dev` → http://localhost:3000/new to confirm onboarding works.
+2. **Name it** following the agreed `<team>-roadmap-dashboard` convention.
+3. **Invite the core team** (manager, tech lead, and primary engineer) so they receive
+   notifications from the start.
+
+### 5–15 min — Configure locally
+
+4. **Install dependencies** locally: `npm install` then copy `.env.example` to `.env.local`.
+5. **Configure credentials** with either the GitHub App (preferred) or a short-lived PAT.
+6. **Update `.roadmaprc.json`** with the correct `READ_ONLY_CHECKS_URL` for your Supabase
+   Edge function (or equivalent read-only verifier).
+
+### 15–25 min — Align the roadmap
+
+7. **Edit `docs/roadmap.yml`** to reflect the actual initiatives and dependent files.
+8. **Run `npm run roadmap:check`** to validate files exist before pushing your first branch.
+9. **Commit & push** so the Roadmap Checks workflow runs and updates the status badge.
+
+### 25–30 min — Demo and hand-off
+
+10. **Open the dashboard** at `npm run dev` → http://localhost:3000/new and walk through the
+    onboarding wizard with the stakeholders.
+11. **Log immediate follow-ups** (missing files, doc gaps, new automation ideas) in the
+    roadmap backlog before everyone leaves the room.
 
 ## Timeline & owners
 

--- a/docs/roadmap.yml
+++ b/docs/roadmap.yml
@@ -40,6 +40,15 @@ weeks:
             files:
               - app/page.tsx
               - app/HomeClient.tsx
+  - id: w05
+    title: Weeks 9–10 — PR automations
+    items:
+      - id: status-badge
+        name: Repo README shows live status badge
+        checks:
+          - type: files_exist
+            files:
+              - README.md
   - id: w12
     title: Weeks 23–24 — Packaging & docs
     items:


### PR DESCRIPTION
## Summary
- add a GitHub Actions status badge placeholder to the README with guidance on updating the repo slug
- extend the roadmap.yml plan with the PR automation milestone that tracks the badge file
- rewrite the 30-minute adoption one-pager with TL;DR, prerequisites, and time-boxed steps

## Testing
- npm run roadmap:check

------
https://chatgpt.com/codex/tasks/task_e_68cf3c89dcb0832d806e1168e042cbb2