### PR TITLE
Add dashboard guide for Supabase read_only_checks edge function

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -31,6 +31,19 @@ a{ color:var(--accent); text-decoration:none }
 h1,h2,h3{ margin:0 0 8px }
 h1{ font-size:28px } h2{ font-size:20px; color:#cfe2f3 }
 code{ background:#0f1520; padding:2px 6px; border-radius:6px; border:1px solid #1f2732 }
+pre{ background:#0f1520; border:1px solid #293241; border-radius:12px; padding:12px; color:var(--fg); font-size:13px; line-height:1.55; overflow:auto }
+pre code{ background:transparent; border:none; padding:0; display:block; white-space:pre; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace }
+.guide-card{ display:grid; gap:18px; font-size:14px; line-height:1.6 }
+.guide-card h2{ font-size:20px; margin:0; color:#cfe2f3 }
+.guide-summary{ margin:0; color:var(--muted); font-size:14px; line-height:1.5 }
+.guide-summary code{ margin:0 4px; font-size:13px }
+.guide-steps{ margin:0; padding-left:20px; display:grid; gap:16px }
+.guide-steps > li{ color:var(--muted); }
+.guide-steps > li strong{ display:block; margin-bottom:6px; color:var(--fg) }
+.guide-list{ margin:8px 0 0; padding-left:18px; display:grid; gap:6px; font-size:14px; color:var(--muted) }
+.guide-inline{ margin:8px 0 0; font-size:13px; color:var(--muted); line-height:1.5 }
+.guide-inline code{ margin:0 4px 0 0 }
+.guide-actions{ display:flex; flex-wrap:wrap; gap:8px; margin:8px 0 }
 ul{ padding-left:18px } button{ background:#1b2430; border:1px solid #293241; color:var(--fg); border-radius:10px; padding:10px 14px; cursor:pointer }
 input,textarea{ background:#0f1520; border:1px solid #293241; color:var(--fg); padding:8px 10px; border-radius:8px; width:100% }
 label{ display:block; font-size:14px; color:var(--muted); margin:8px 0 4px }


### PR DESCRIPTION
## Summary
- add a "Create Edge Function" card to the dashboard with detailed Supabase setup guidance, CLI commands, and copy helpers
- embed the read_only_checks edge function source, CLI workflow, and curl smoke-test snippets for quick copying
- style the new documentation card and code blocks for readability

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf5b5b41f8832dba94c41bf13fb7b8