### PR TITLE
Restore setup PR link in dashboard

### DIFF
--- a/app/new/page.tsx
+++ b/app/new/page.tsx
@@ -1,49 +1,85 @@
-'use client';
-import React, { useState } from 'react';
-import { useSearchParams } from 'next/navigation';
+"use client";
 
-export default function Wizard() {
+import React, { Suspense, useState } from "react";
+import { useSearchParams } from "next/navigation";
+
+type WizardResult = Record<string, unknown> | null;
+
+function WizardForm() {
   const search = useSearchParams();
-  const [owner, setOwner] = useState(() => search.get('owner') ?? 'acme');
-  const [repo, setRepo] = useState(() => search.get('repo') ?? 'roadmap-kit-starter');
-  const [branch, setBranch] = useState(() => search.get('branch') ?? 'chore/roadmap-setup');
+  const [owner, setOwner] = useState(() => search.get("owner") ?? "acme");
+  const [repo, setRepo] = useState(() => search.get("repo") ?? "roadmap-kit-starter");
+  const [branch, setBranch] = useState(() => search.get("branch") ?? "chore/roadmap-setup");
   const [readOnlyUrl, setReadOnlyUrl] = useState(
-    () => search.get('readOnlyUrl') ?? 'https://<ref>.functions.supabase.co/read_only_checks'
+    () => search.get("readOnlyUrl") ?? "https://<ref>.functions.supabase.co/read_only_checks"
   );
   const [loading, setLoading] = useState(false);
-  const [result, setResult] = useState<any>(null);
+  const [result, setResult] = useState<WizardResult>(null);
 
   const submit = async () => {
     setLoading(true);
     setResult(null);
-    const r = await fetch('/api/setup', {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ owner, repo, branch, readOnlyUrl })
-    });
-    const j = await r.json();
-    setLoading(false);
-    setResult(j);
+    try {
+      const response = await fetch("/api/setup", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ owner, repo, branch, readOnlyUrl }),
+      });
+      const json = await response.json();
+      setResult(json);
+    } catch (error) {
+      setResult({ error: error instanceof Error ? error.message : "Failed to create PR" });
+    } finally {
+      setLoading(false);
+    }
   };
 
   return (
     <div className="card">
       <h2>Onboarding Wizard</h2>
       <div className="form-row">
-        <div><label>GitHub Owner</label><input value={owner} onChange={e=>setOwner(e.target.value)} /></div>
-        <div><label>Repository</label><input value={repo} onChange={e=>setRepo(e.target.value)} /></div>
+        <div>
+          <label>GitHub Owner</label>
+          <input value={owner} onChange={(event) => setOwner(event.target.value)} />
+        </div>
+        <div>
+          <label>Repository</label>
+          <input value={repo} onChange={(event) => setRepo(event.target.value)} />
+        </div>
       </div>
       <div className="form-row">
-        <div><label>Branch name for PR</label><input value={branch} onChange={e=>setBranch(e.target.value)} /></div>
-        <div><label>READ_ONLY_CHECKS_URL</label><input value={readOnlyUrl} onChange={e=>setReadOnlyUrl(e.target.value)} /></div>
-      </div>
-      <div style={{height:12}} />
-      <button onClick={submit} disabled={loading}>{loading ? 'Creating PR…' : 'Create Setup PR'}</button>
-      {result && (
-        <div style={{marginTop:12}}>
-          {result.url ? <a href={result.url} target="_blank" rel="noreferrer">Open PR</a> : <pre>{JSON.stringify(result, null, 2)}</pre>}
+        <div>
+          <label>Branch name for PR</label>
+          <input value={branch} onChange={(event) => setBranch(event.target.value)} />
         </div>
-      )}
+        <div>
+          <label>READ_ONLY_CHECKS_URL</label>
+          <input value={readOnlyUrl} onChange={(event) => setReadOnlyUrl(event.target.value)} />
+        </div>
+      </div>
+      <div style={{ height: 12 }} />
+      <button type="button" onClick={submit} disabled={loading}>
+        {loading ? "Creating PR…" : "Create Setup PR"}
+      </button>
+      {result ? (
+        <div style={{ marginTop: 12 }}>
+          {typeof result === "object" && result && "url" in result && typeof result.url === "string" ? (
+            <a href={result.url} target="_blank" rel="noreferrer">
+              Open PR
+            </a>
+          ) : (
+            <pre>{JSON.stringify(result, null, 2)}</pre>
+          )}
+        </div>
+      ) : null}
     </div>
+  );
+}
+
+export default function Wizard() {
+  return (
+    <Suspense fallback={<div className="card">Loading wizard…</div>}>
+      <WizardForm />
+    </Suspense>
   );
 }

--- a/app/new/page.tsx
+++ b/app/new/page.tsx
@@ -1,11 +1,15 @@
 'use client';
 import React, { useState } from 'react';
+import { useSearchParams } from 'next/navigation';
 
 export default function Wizard() {
-  const [owner, setOwner] = useState('acme');
-  const [repo, setRepo] = useState('roadmap-kit-starter');
-  const [branch, setBranch] = useState('chore/roadmap-setup');
-  const [readOnlyUrl, setReadOnlyUrl] = useState('https://<ref>.functions.supabase.co/read_only_checks');
+  const search = useSearchParams();
+  const [owner, setOwner] = useState(() => search.get('owner') ?? 'acme');
+  const [repo, setRepo] = useState(() => search.get('repo') ?? 'roadmap-kit-starter');
+  const [branch, setBranch] = useState(() => search.get('branch') ?? 'chore/roadmap-setup');
+  const [readOnlyUrl, setReadOnlyUrl] = useState(
+    () => search.get('readOnlyUrl') ?? 'https://<ref>.functions.supabase.co/read_only_checks'
+  );
   const [loading, setLoading] = useState(false);
   const [result, setResult] = useState<any>(null);
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1574,7 +1574,7 @@ function DashboardPage() {
               <code>
                 {activeRepo.owner}/{activeRepo.repo}
               </code>
-              <a href={wizardHref} target="_blank" rel="noreferrer">
+              <a className="project-wizard" href={wizardHref} target="_blank" rel="noreferrer">
                 Create setup PR ↗
               </a>
               <a href={`/api/status/${activeRepo.owner}/${activeRepo.repo}`} target="_blank" rel="noreferrer">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1436,6 +1436,13 @@ function DashboardPage() {
     if (!activeKey) return null;
     return repos.find((repo) => repoKey(repo.owner, repo.repo) === activeKey) ?? null;
   }, [repos, activeKey]);
+  const wizardHref = useMemo(() => {
+    if (!activeRepo) return "/new";
+    const params = new URLSearchParams();
+    params.set("owner", activeRepo.owner);
+    params.set("repo", activeRepo.repo);
+    return `/new?${params.toString()}`;
+  }, [activeRepo]);
 
   useEffect(() => {
     if (!initialized) return;
@@ -1567,6 +1574,9 @@ function DashboardPage() {
               <code>
                 {activeRepo.owner}/{activeRepo.repo}
               </code>
+              <a href={wizardHref} target="_blank" rel="noreferrer">
+                Create setup PR ↗
+              </a>
               <a href={`/api/status/${activeRepo.owner}/${activeRepo.repo}`} target="_blank" rel="noreferrer">
                 View status JSON ↗
               </a>


### PR DESCRIPTION
## Summary
- add a Create setup PR link to the active repo header so the onboarding wizard is visible again
- pre-fill the wizard inputs from URL query parameters to open it ready for the selected repo

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d430c151e0832d8342b6dc1bbf3a40