### PR TITLE
feat: add onboarding checklist guidance

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -50,6 +50,27 @@ label{ display:block; font-size:14px; color:var(--muted); margin:8px 0 4px }
 .form-row{ display:grid; gap:10px; grid-template-columns: 1fr 1fr }
 textarea{ min-height:180px; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace }
 
+.onboarding-card{ display:grid; gap:20px }
+.onboarding-header{ display:grid; gap:8px }
+.onboarding-summary{ margin:0; color:var(--muted); font-size:14px; line-height:1.6 }
+.onboarding-summary code{ font-size:13px }
+.onboarding-list{ margin:0; padding-left:22px; display:grid; gap:18px }
+.onboarding-step{ display:grid; gap:12px; color:var(--muted) }
+.onboarding-step-header{ display:flex; flex-wrap:wrap; gap:12px; align-items:flex-start; justify-content:space-between }
+.onboarding-step-title{ font-size:16px; font-weight:600; color:var(--fg) }
+.onboarding-step-description{ margin:8px 0 0; font-size:14px; line-height:1.5; color:var(--muted); max-width:720px }
+.onboarding-step-description code{ font-size:13px }
+.onboarding-details{ background:rgba(15,21,32,0.7); border:1px solid #1f2732; border-radius:12px; padding:12px 14px }
+.onboarding-details summary{ cursor:pointer; font-size:13px; color:var(--muted); display:flex; align-items:center; gap:6px; outline:none }
+.onboarding-details summary::-webkit-details-marker{ display:none }
+.onboarding-details summary::before{ content:"＋"; color:var(--accent); font-weight:600 }
+.onboarding-details[open] summary{ color:var(--accent); margin-bottom:12px }
+.onboarding-details[open] summary::before{ content:"−" }
+.onboarding-details pre{ margin:0 0 12px }
+.onboarding-details pre:last-of-type{ margin-bottom:0 }
+.onboarding-note{ font-size:13px; color:var(--muted); line-height:1.5 }
+.onboarding-note code{ font-size:12px }
+
 .dashboard{ display:grid; gap:18px; min-width:0 }
 .repo-line{ display:flex; flex-wrap:wrap; gap:10px; align-items:center; font-size:14px; color:var(--muted) }
 .repo-label{ opacity:0.85 }


### PR DESCRIPTION
## Summary
- add an onboarding checklist card that detects roadmap checks and surfaces their status inline
- include copy-ready snippets for the roadmap checker, workflow, and secrets so repos are easier to wire up
- style the new checklist layout to match the dashboard cards

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4ab323780832d88b540939a3782f1