### PR TITLE
Fix project sidebar hover layout shift

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -152,7 +152,10 @@ textarea{ min-height:180px; font-family: ui-monospace, SFMono-Regular, Menlo, Mo
 .project-wizard:hover{ text-decoration:underline }
 .project-hint{ font-size:12px; color:var(--muted) }
 .project-empty{ font-size:13px; color:var(--muted); background:rgba(11,17,25,0.65); border:1px dashed rgba(148,163,184,0.35); padding:12px 14px; border-radius:12px }
-.project-panel-body{ display:grid; gap:16px; flex:1; min-height:0; overflow:auto; padding-right:6px; scrollbar-gutter:stable both-edges }
+.project-panel-body{ display:grid; gap:16px; flex:1; min-height:0; overflow:auto; width:calc(100% + 18px); padding-right:18px; margin-right:-18px }
+@supports (scrollbar-gutter:stable){
+  .project-panel-body{ width:auto; margin-right:0; padding-right:6px; scrollbar-gutter:stable both-edges }
+}
 .project-list{ list-style:none; margin:0; padding:0; display:grid; gap:10px }
 .project-item{ display:flex; align-items:center; gap:10px }
 .project-button{ flex:1; border:1px solid #1f2732; background:rgba(11,17,25,0.7); color:var(--fg); padding:10px 12px; border-radius:12px; font-size:13px; display:flex; align-items:center; justify-content:space-between; transition:border-color 0.2s ease, background 0.2s ease }
@@ -205,4 +208,4 @@ button.ghost-button:disabled{ opacity:0.6; cursor:not-allowed; background:transp
 .add-project-hints code{ font-size:12px }
 
 @media (min-width:560px){ .project-form-row{ grid-template-columns:repeat(2,minmax(0,1fr)) } }
-@media (max-width:980px){ .dashboard-shell{ grid-template-columns:1fr } .project-panel{ position:relative; top:auto; max-height:none; overflow:visible } }
+@media (max-width:980px){ .dashboard-shell{ grid-template-columns:1fr } .project-panel{ position:relative; top:auto; max-height:none; overflow:visible } .project-panel-body{ width:100%; margin-right:0; padding-right:0; overflow:visible } }


### PR DESCRIPTION
## Summary
- reserve horizontal space for the project sidebar scrollbar so it no longer jumps when it appears
- keep the mobile layout unaffected by resetting the sidebar overflow adjustments below 980px

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4b861f480832dbfcacefffb11c0d2