### PR TITLE
Style copy actions and incomplete list

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -107,6 +107,15 @@ textarea{ min-height:180px; font-family: ui-monospace, SFMono-Regular, Menlo, Mo
 .progress-fill.pending{ background:rgba(148,163,184,0.65) }
 .progress-legend{ font-size:12px; color:var(--muted) }
 
+.copy-button{ display:inline-flex; align-items:center; gap:6px; border-radius:10px; border:1px solid rgba(78,161,255,0.35); background:rgba(15,21,32,0.8); color:var(--fg); font-size:13px; padding:8px 12px; cursor:pointer; transition:background 0.2s ease, border-color 0.2s ease, color 0.2s ease }
+.copy-button:hover{ background:rgba(78,161,255,0.12); border-color:rgba(78,161,255,0.55) }
+.copy-button:disabled{ opacity:0.55; cursor:not-allowed; background:rgba(15,21,32,0.6); border-color:rgba(78,161,255,0.25); color:var(--muted) }
+.copy-button.copy-small{ font-size:12px; padding:6px 10px }
+.copy-button.copy-default{ font-size:13px }
+.copy-button.copy-success{ border-color:rgba(52,211,153,0.65); background:var(--success-bg); color:var(--success) }
+.copy-button.copy-error{ border-color:rgba(248,113,113,0.65); background:var(--danger-bg); color:var(--danger) }
+.copy-button-icon{ font-size:14px; line-height:1 }
+
 .week-grid{ display:grid; gap:18px }
 .week-card{ background:var(--card); border:1px solid #1f2732; border-radius:20px; padding:20px; display:grid; gap:16px }
 .week-card.week-success{ border-color:rgba(52,211,153,0.35) }
@@ -143,6 +152,17 @@ textarea{ min-height:180px; font-family: ui-monospace, SFMono-Regular, Menlo, Mo
 
 .empty-subtasks{ font-size:13px; color:var(--muted) }
 .timestamp{ font-size:12px; color:var(--muted) }
+
+.incomplete-card{ background:var(--card); border:1px solid #1f2732; border-radius:18px; padding:18px; display:grid; gap:16px }
+.incomplete-actions{ display:flex; flex-wrap:wrap; gap:8px; align-items:center }
+.incomplete-list{ list-style:none; margin:0; padding:0; display:grid; gap:12px }
+.incomplete-item{ background:rgba(11,17,25,0.8); border:1px solid #1f2732; border-radius:14px; padding:14px; display:grid; gap:10px }
+.incomplete-item-header{ display:flex; flex-wrap:wrap; align-items:flex-start; justify-content:space-between; gap:8px }
+.incomplete-item-title{ font-size:15px; font-weight:600; color:var(--fg) }
+.incomplete-item-meta{ font-size:12px; color:var(--muted) }
+.incomplete-item-week{ font-size:12px; color:var(--muted) }
+.incomplete-item-status{ font-size:13px; color:var(--muted) }
+.incomplete-blockers{ margin:0; padding-left:18px; display:grid; gap:6px; font-size:13px; color:var(--muted) }
 
 .dashboard-shell{ display:grid; gap:24px; grid-template-columns:minmax(0,280px) minmax(0,1fr); align-items:flex-start }
 .project-panel{ background:var(--card); border:1px solid #1f2732; border-radius:20px; padding:20px; display:flex; flex-direction:column; gap:16px; position:sticky; top:24px; min-width:0; max-height:calc(100vh - 48px); overflow:hidden }


### PR DESCRIPTION
## Summary
- style the copy buttons so they blend with the dark dashboard theme and reflect success or error states
- add styling for the incomplete summary list so the rows no longer render as stark white blocks

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4ba42a634832d96db77f7a78c8f7e