### PR TITLE
Improve GitHub App diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,15 @@ npm run dev
 - `POST /api/verify` — proxy to your READ_ONLY_CHECKS_URL
 - `POST /api/webhook` — optional GitHub webhook endpoint
 
+### Verify your GitHub App env vars
+
+1. Run `npm run check-env` (or `node scripts/check-env.mjs`) locally. The script prints whether `GH_APP_ID` and the private-key
+   variables are detected and previews the first/last characters so you can confirm the formatting.
+2. If you are using a raw PEM private key, make sure the value in `.env.local` contains real newlines. When in doubt, base64 encode it
+   with `openssl base64 -A -in your-key.pem` and paste the single-line output into `GH_APP_PRIVATE_KEY_B64` instead.
+3. Commit **only** `.env.example`. Keep `.env.local` and the PEM file out of git (they are ignored by default) and mirror the same
+   values inside your Vercel project under *Settings → Environment Variables*.
+
 ## Deploy (Vercel)
 
 Add env vars (Production + Preview):
@@ -31,3 +40,5 @@ Add env vars (Production + Preview):
 - or **PAT**: `GITHUB_TOKEN`
 - `READ_ONLY_CHECKS_URL` for the verify API
 - (optional) `GITHUB_WEBHOOK_SECRET` if you add a webhook
+
+> **Security tip:** Store these secrets in your deployment platform (e.g., Vercel env vars) or in a local `.env.local` file for development. Do **not** commit GitHub App credentials to your roadmap repo—no branch should contain the raw private key.


### PR DESCRIPTION
## Summary
- surface GitHub App token acquisition status to the status endpoint response so private repos fail with actionable errors
- log token minting failures and attach headers/messages that highlight missing env vars
- document a repeatable process for verifying GitHub App environment variables locally and in Vercel

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4b4f92ae8832d934d5133fa6f6242