### PR TITLE
Fix focus outline artifacts in Chrome

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -15,8 +15,14 @@
 }
 *{ box-sizing:border-box; scrollbar-width:thin; scrollbar-color:rgba(78,161,255,0.35) transparent }
 html,body{ margin:0; padding:0; background:var(--bg); color:var(--fg); font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Arial; -webkit-tap-highlight-color:rgba(78,161,255,0.15) }
-:focus-visible{ outline:2px solid var(--accent); outline-offset:3px; border-radius:6px }
-:focus:not(:focus-visible){ outline:none }
+:where(a,button,input,textarea,select,summary,[role="button"],[tabindex]:not([tabindex="-1"])):focus-visible{
+  outline:none;
+  box-shadow:0 0 0 2px rgba(78,161,255,0.6);
+}
+:where(a,button,input,textarea,select,summary,[role="button"],[tabindex]:not([tabindex="-1"])):focus:not(:focus-visible){
+  outline:none;
+  box-shadow:none;
+}
 *::-webkit-scrollbar{ width:12px; height:12px }
 *::-webkit-scrollbar-track{ background:transparent }
 *::-webkit-scrollbar-thumb{ background-color:rgba(78,161,255,0.35); border-radius:999px; border:3px solid transparent; background-clip:content-box }


### PR DESCRIPTION
## Summary
- replace the global focus outline with a subtler box-shadow ring on interactive controls
- prevent the large white focus rectangles that appeared after clicking around in Chrome while keeping focus styling accessible

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d8a7054b54832da0b5792b908b070b