### PR TITLE
Broaden focus styles to prevent white overlays

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -15,11 +15,12 @@
 }
 *{ box-sizing:border-box; scrollbar-width:thin; scrollbar-color:rgba(78,161,255,0.35) transparent }
 html,body{ margin:0; padding:0; background:var(--bg); color:var(--fg); font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Arial; -webkit-tap-highlight-color:rgba(78,161,255,0.15) }
-:where(a,button,input,textarea,select,summary,[role="button"],[tabindex]:not([tabindex="-1"])):focus-visible{
+:where(:not(html,body)):focus-visible{
   outline:none;
   box-shadow:0 0 0 2px rgba(78,161,255,0.6);
+  border-radius:8px;
 }
-:where(a,button,input,textarea,select,summary,[role="button"],[tabindex]:not([tabindex="-1"])):focus:not(:focus-visible){
+:where(:not(html,body)):focus:not(:focus-visible){
   outline:none;
   box-shadow:none;
 }


### PR DESCRIPTION
## Summary
- extend the global focus-visible selector to cover all focusable elements while excluding the document root
- keep custom focus styling consistent and add a radius to avoid large white focus blocks in Chrome

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d8b4c11f6c832da35d149b491264e1