### PR TITLE
Support GitHub App tokens in status route

### DIFF
--- a/app/api/status/[owner]/[repo]/route.ts
+++ b/app/api/status/[owner]/[repo]/route.ts
@@ -2,63 +2,56 @@
 import { NextResponse } from "next/server";
 import yaml from "js-yaml";
 
+import { authHeaders, getTokenForRepo, type RepoAuth } from "@/lib/token";
+
 export const runtime = "nodejs";
 
 const DEFAULT_BRANCH = process.env.DEFAULT_BRANCH || "main";
 const REVALIDATE_SECS = 15;
 const UA = "roadmap-dashboard-pro";
 
-function hasGitHubAppConfig() {
-  return Boolean(
-    process.env.GH_APP_ID &&
-      (process.env.GH_APP_PRIVATE_KEY_B64 || process.env.GH_APP_PRIVATE_KEY)
-  );
-}
-
 type TokenResult =
-  | { token: string; status: "ok" }
-  | { token: undefined; status: "missing" | "error"; message?: string };
+  | { status: "ok"; auth: RepoAuth }
+  | { status: "missing" | "error"; auth: undefined; message?: string };
 
-async function tryGetInstallationToken(): Promise<TokenResult> {
-  if (!hasGitHubAppConfig()) {
-    return { token: undefined, status: "missing", message: "GH_APP_ID/GH_APP_PRIVATE_KEY not set" };
-  }
+async function resolveRepoAuth(owner: string, repo: string): Promise<TokenResult> {
   try {
-    const mod = await import("@/lib/githubApp");
-    const token = await mod.getInstallationToken();
-    return { token, status: "ok" };
+    const auth = await getTokenForRepo(owner, repo);
+    return { status: "ok", auth };
   } catch (error: any) {
     const message = error?.message ? String(error.message) : undefined;
-    console.error("github-app-token", message ?? error);
-    return { token: undefined, status: "error", message };
+    const missing = message?.includes("No GitHub credentials configured");
+    if (!missing) {
+      console.error("github-token", message ?? error);
+    }
+    return { status: missing ? "missing" : "error", auth: undefined, message };
   }
 }
 
 type Ctx = { params: { owner: string; repo: string } };
 type GHContentsResp = { content?: string; encoding?: string };
 
-function ghHeaders(token?: string) {
-  const h: Record<string, string> = { Accept: "application/vnd.github+json", "User-Agent": UA };
-  if (token) h.Authorization = `Bearer ${token}`;
-  return h;
+function ghHeaders(auth?: RepoAuth) {
+  const base = { Accept: "application/vnd.github+json", "User-Agent": UA };
+  return auth ? authHeaders(auth, base) : base;
 }
 
-async function fetchJSON(url: string, token?: string) {
-  const r = await fetch(url, { headers: ghHeaders(token), next: { revalidate: REVALIDATE_SECS } });
+async function fetchJSON(url: string, auth?: RepoAuth) {
+  const r = await fetch(url, { headers: ghHeaders(auth), next: { revalidate: REVALIDATE_SECS } });
   if (!r.ok) throw new Error(`${r.status} ${r.statusText} for ${url}`);
   return r.json();
 }
-async function fetchText(url: string, token?: string) {
-  const r = await fetch(url, { headers: ghHeaders(token), next: { revalidate: REVALIDATE_SECS } });
+async function fetchText(url: string, auth?: RepoAuth) {
+  const r = await fetch(url, { headers: ghHeaders(auth), next: { revalidate: REVALIDATE_SECS } });
   if (!r.ok) throw new Error(`${r.status} ${r.statusText} for ${url}`);
   return r.text();
 }
 
 /** Repo default branch (best-effort) */
-async function detectDefaultBranch(owner: string, repo: string, token?: string) {
-  if (!token) return null;
+async function detectDefaultBranch(owner: string, repo: string, auth?: RepoAuth) {
+  if (!auth) return null;
   try {
-    const j = (await fetchJSON(`https://api.github.com/repos/${owner}/${repo}`, token)) as {
+    const j = (await fetchJSON(`https://api.github.com/repos/${owner}/${repo}`, auth)) as {
       default_branch?: string;
     };
     return j.default_branch ?? null;
@@ -68,12 +61,12 @@ async function detectDefaultBranch(owner: string, repo: string, token?: string) 
 }
 
 /** Contents API → decode base64 if present */
-async function fetchViaContentsAPI(owner: string, repo: string, path: string, ref: string, token?: string) {
-  if (!token) return null;
+async function fetchViaContentsAPI(owner: string, repo: string, path: string, ref: string, auth?: RepoAuth) {
+  if (!auth) return null;
   const url = `https://api.github.com/repos/${owner}/${repo}/contents/${encodeURIComponent(
     path
   )}?ref=${encodeURIComponent(ref)}`;
-  const r = await fetch(url, { headers: ghHeaders(token), next: { revalidate: REVALIDATE_SECS } });
+  const r = await fetch(url, { headers: ghHeaders(auth), next: { revalidate: REVALIDATE_SECS } });
   if (!r.ok) return null;
 
   try {
@@ -94,8 +87,8 @@ async function fetchViaRaw(owner: string, repo: string, path: string, ref: strin
   return r.text();
 }
 /** Try API then raw */
-async function loadFile(owner: string, repo: string, path: string, ref: string, token?: string) {
-  const viaApi = await fetchViaContentsAPI(owner, repo, path, ref, token);
+async function loadFile(owner: string, repo: string, path: string, ref: string, auth?: RepoAuth) {
+  const viaApi = await fetchViaContentsAPI(owner, repo, path, ref, auth);
   if (viaApi !== null) return viaApi;
   const viaRaw = await fetchViaRaw(owner, repo, path, ref);
   if (viaRaw !== null) return viaRaw;
@@ -103,12 +96,12 @@ async function loadFile(owner: string, repo: string, path: string, ref: string, 
 }
 
 /** HEAD/GET presence check for a repo path */
-async function fileExists(owner: string, repo: string, path: string, ref: string, token?: string) {
-  if (token) {
+async function fileExists(owner: string, repo: string, path: string, ref: string, auth?: RepoAuth) {
+  if (auth) {
     const u = `https://api.github.com/repos/${owner}/${repo}/contents/${encodeURIComponent(
       path
     )}?ref=${encodeURIComponent(ref)}`;
-    const r = await fetch(u, { headers: ghHeaders(token), next: { revalidate: REVALIDATE_SECS } });
+    const r = await fetch(u, { headers: ghHeaders(auth), next: { revalidate: REVALIDATE_SECS } });
     if (r.ok) return true;
   }
   const url = `https://raw.githubusercontent.com/${owner}/${repo}/${encodeURIComponent(ref)}/${path}`;
@@ -125,7 +118,7 @@ async function runCheck(
   owner: string,
   repo: string,
   branch: string,
-  token: string | undefined,
+  auth: RepoAuth | undefined,
   rc: any,
   check: any
 ): Promise<{ status: "pass" | "fail" | "skip"; note?: string }> {
@@ -147,7 +140,7 @@ async function runCheck(
 
     for (const p of paths) {
       // eslint-disable-next-line no-await-in-loop
-      const ok = await fileExists(owner, repo, p, branch, token);
+      const ok = await fileExists(owner, repo, p, branch, auth);
       if (!ok) return { status: "fail", note: `missing: ${p}` };
     }
     return { status: "pass", note: `${paths.length} file(s) present` };
@@ -252,7 +245,7 @@ async function enrichWeeks(
     owner: string;
     repo: string;
     branch: string;
-    token?: string;
+    auth?: RepoAuth;
     rc: any;
     mode: EnrichMode;
   }
@@ -283,7 +276,7 @@ async function enrichWeeks(
         for (const check of sourceChecks) {
           const base = cloneCheck(check);
           // eslint-disable-next-line no-await-in-loop
-          const result = await runCheck(ctx.owner, ctx.repo, ctx.branch, ctx.token, ctx.rc, check);
+          const result = await runCheck(ctx.owner, ctx.repo, ctx.branch, ctx.auth, ctx.rc, check);
           base.status = result.status;
           base.result = result.status;
           if (result.note !== undefined) base.note = result.note;
@@ -325,17 +318,17 @@ async function enrichWeeks(
 export async function GET(_req: Request, { params }: Ctx) {
   const { owner, repo } = params;
 
-  const tokenResult = await tryGetInstallationToken();
-  const token = tokenResult.token;
+  const tokenResult = await resolveRepoAuth(owner, repo);
+  const auth = tokenResult.status === "ok" ? tokenResult.auth : undefined;
 
-  const branch = (await detectDefaultBranch(owner, repo, token)) || DEFAULT_BRANCH;
+  const branch = (await detectDefaultBranch(owner, repo, auth)) || DEFAULT_BRANCH;
 
   const statusPath = "docs/roadmap-status.json";
-  const statusTxt = await loadFile(owner, repo, statusPath, branch, token);
+  const statusTxt = await loadFile(owner, repo, statusPath, branch, auth);
   if (statusTxt) {
     try {
       const json = JSON.parse(statusTxt);
-      const weeks = await enrichWeeks(json?.weeks, { owner, repo, branch, token, rc: null, mode: "artifact" });
+      const weeks = await enrichWeeks(json?.weeks, { owner, repo, branch, auth, rc: null, mode: "artifact" });
       const payload: any = {
         ...json,
         owner: json?.owner ?? owner,
@@ -351,14 +344,18 @@ export async function GET(_req: Request, { params }: Ctx) {
       payload.source = { ...sourceMeta, artifact: statusPath };
 
       return NextResponse.json(payload, {
-        headers: { "cache-control": "no-store", "x-status-route": "artifact" },
+        headers: {
+          "cache-control": "no-store",
+          "x-status-route": "artifact",
+          ...(auth ? { "x-github-auth-source": auth.source } : {}),
+        },
       });
     } catch {}
   }
 
   let rc: any = null;
   let roadmapPath = "docs/roadmap.yml";
-  const rcTxt = await loadFile(owner, repo, ".roadmaprc.json", branch, token);
+  const rcTxt = await loadFile(owner, repo, ".roadmaprc.json", branch, auth);
   if (rcTxt) {
     try {
       rc = JSON.parse(rcTxt);
@@ -366,7 +363,7 @@ export async function GET(_req: Request, { params }: Ctx) {
     } catch {}
   }
 
-  const roadmapTxt = await loadFile(owner, repo, roadmapPath, branch, token);
+  const roadmapTxt = await loadFile(owner, repo, roadmapPath, branch, auth);
   if (!roadmapTxt) {
     const missingPayload: Record<string, unknown> = {
       ok: false,
@@ -376,7 +373,7 @@ export async function GET(_req: Request, { params }: Ctx) {
       branch,
     };
 
-    if (!token && tokenResult.status !== "ok") {
+    if (!auth && tokenResult.status !== "ok") {
       missingPayload.error = "GITHUB_APP_TOKEN_UNAVAILABLE";
       missingPayload.message =
         tokenResult.status === "missing"
@@ -391,6 +388,7 @@ export async function GET(_req: Request, { params }: Ctx) {
         "cache-control": "no-store",
         "x-status-route": "missing",
         "x-github-app": tokenResult.status,
+        ...(auth ? { "x-github-auth-source": auth.source } : {}),
       },
     });
   }
@@ -401,11 +399,17 @@ export async function GET(_req: Request, { params }: Ctx) {
   } catch (e: any) {
     return NextResponse.json(
       { ok: false, error: "YAML_PARSE_FAILED", message: e?.message || String(e) },
-      { status: 500, headers: { "cache-control": "no-store" } }
+      {
+        status: 500,
+        headers: {
+          "cache-control": "no-store",
+          ...(auth ? { "x-github-auth-source": auth.source } : {}),
+        },
+      }
     );
   }
 
-  const weeks = await enrichWeeks(doc?.weeks, { owner, repo, branch, token, rc, mode: "live" });
+  const weeks = await enrichWeeks(doc?.weeks, { owner, repo, branch, auth, rc, mode: "live" });
 
   return NextResponse.json(
     {
@@ -418,6 +422,12 @@ export async function GET(_req: Request, { params }: Ctx) {
       source: { rc: !!rcTxt, roadmap: roadmapPath },
       weeks,
     },
-    { headers: { "cache-control": "no-store", "x-status-route": "yaml-live" } }
+    {
+      headers: {
+        "cache-control": "no-store",
+        "x-status-route": "yaml-live",
+        ...(auth ? { "x-github-auth-source": auth.source } : {}),
+      },
+    }
   );
 }

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -29,23 +29,27 @@ export async function getFileRaw({
   repo,
   path,
   ref,
+  auth,
 }: {
   owner: string;
   repo: string;
   path: string;
   ref?: string;
+  auth?: RepoAuth;
 }) {
-  let auth: RepoAuth | undefined;
-  try {
-    auth = await getTokenForRepo(owner, repo);
-  } catch (error: any) {
-    const message = error?.message ? String(error.message) : "";
-    const missingCreds = message.includes("No GitHub credentials configured");
-    if (!missingCreds) throw error;
+  let repoAuth = auth;
+  if (!repoAuth) {
+    try {
+      repoAuth = await getTokenForRepo(owner, repo);
+    } catch (error: any) {
+      const message = error?.message ? String(error.message) : "";
+      const missingCreds = message.includes("No GitHub credentials configured");
+      if (!missingCreds) throw error;
+    }
   }
 
-  if (auth) {
-    const viaApi = await fetchRepoFile({ owner, repo, path, ref, auth });
+  if (repoAuth) {
+    const viaApi = await fetchRepoFile({ owner, repo, path, ref, auth: repoAuth });
     if (viaApi !== null) return viaApi;
   }
 

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -1,4 +1,6 @@
-import { RepoAuth, authHeaders } from "./token";
+import { RepoAuth, authHeaders, getTokenForRepo } from "./token";
+
+const RAW_ACCEPT_HEADER = { Accept: "application/vnd.github.v3.raw" } as const;
 
 export async function fetchRepoFile({
   owner,
@@ -15,9 +17,24 @@ export async function fetchRepoFile({
 }) {
   const url = `https://api.github.com/repos/${owner}/${repo}/contents/${encodeURIComponent(path)}${ref ? `?ref=${ref}` : ""}`;
   const r = await fetch(url, {
-    headers: authHeaders(auth, { Accept: "application/vnd.github.v3.raw" }),
+    headers: authHeaders(auth, RAW_ACCEPT_HEADER),
     cache: "no-store",
   });
   if (!r.ok) return null;
   return await r.text();
+}
+
+export async function getFileRaw({
+  owner,
+  repo,
+  path,
+  ref,
+}: {
+  owner: string;
+  repo: string;
+  path: string;
+  ref?: string;
+}) {
+  const auth = await getTokenForRepo(owner, repo);
+  return fetchRepoFile({ owner, repo, path, ref, auth });
 }


### PR DESCRIPTION
## Summary
- reuse the repo token helper inside `lib/github.ts` so raw file reads work with GitHub App installations or PATs
- request repo-scoped credentials in the status API route and reuse them across GitHub fetch helpers
- return clearer diagnostics and headers when credentials are missing, while keeping raw fallbacks for public repos

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68da8c7abe44832d8e3a1988d8334e55