### PR TITLE
Ensure GitHub helpers mint repo tokens and send UA header

### DIFF
--- a/lib/github.ts
+++ b/lib/github.ts
@@ -1,4 +1,23 @@
-import { RepoAuth, authHeaders } from "./token";
+import { RepoAuth, authHeaders, getTokenForRepo } from "./token";
+
+const USER_AGENT = "roadmap-dashboard-pro";
+const RAW_ACCEPT_HEADER: Record<string, string> = { Accept: "application/vnd.github.v3.raw" };
+const API_HEADERS: Record<string, string> = {
+  ...RAW_ACCEPT_HEADER,
+  "User-Agent": USER_AGENT,
+  "X-GitHub-Api-Version": "2022-11-28",
+};
+const RAW_HEADERS: Record<string, string> = {
+  ...RAW_ACCEPT_HEADER,
+  "User-Agent": USER_AGENT,
+};
+
+export function encodeRepoPath(path: string): string {
+  return path
+    .split("/")
+    .map((segment) => encodeURIComponent(segment))
+    .join("/");
+}
 
 export async function fetchRepoFile({
   owner,
@@ -13,11 +32,51 @@ export async function fetchRepoFile({
   ref?: string;
   auth: RepoAuth;
 }) {
-  const url = `https://api.github.com/repos/${owner}/${repo}/contents/${encodeURIComponent(path)}${ref ? `?ref=${ref}` : ""}`;
+  const encodedPath = encodeRepoPath(path);
+  const url = `https://api.github.com/repos/${owner}/${repo}/contents/${encodedPath}${
+    ref ? `?ref=${encodeURIComponent(ref)}` : ""
+  }`;
   const r = await fetch(url, {
-    headers: authHeaders(auth, { Accept: "application/vnd.github.v3.raw" }),
+    headers: authHeaders(auth, API_HEADERS),
     cache: "no-store",
   });
+  if (!r.ok) return null;
+  return await r.text();
+}
+
+export async function getFileRaw({
+  owner,
+  repo,
+  path,
+  ref,
+  auth,
+}: {
+  owner: string;
+  repo: string;
+  path: string;
+  ref?: string;
+  auth?: RepoAuth;
+}) {
+  let repoAuth = auth;
+  if (!repoAuth) {
+    try {
+      repoAuth = await getTokenForRepo(owner, repo);
+    } catch (error: any) {
+      const message = error?.message ? String(error.message) : "";
+      const missingCreds = message.includes("No GitHub credentials configured");
+      if (!missingCreds) throw error;
+    }
+  }
+
+  if (repoAuth) {
+    const viaApi = await fetchRepoFile({ owner, repo, path, ref, auth: repoAuth });
+    if (viaApi !== null) return viaApi;
+  }
+
+  const branch = ref ?? "main";
+  const encodedPath = encodeRepoPath(path);
+  const url = `https://raw.githubusercontent.com/${owner}/${repo}/${encodeURIComponent(branch)}/${encodedPath}`;
+  const r = await fetch(url, { headers: RAW_HEADERS, cache: "no-store" });
   if (!r.ok) return null;
   return await r.text();
 }


### PR DESCRIPTION
## Summary
- reuse the repo-scoped token helper inside the GitHub content fetcher and normalize path encoding across helpers
- have the status API route resolve repo credentials once, fall back gracefully when tokens are missing, and surface diagnostics
- include the GitHub user agent and API version headers on helper fetches so authenticated requests continue to succeed

## Testing
- npm run lint
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da8c7abe44832d8e3a1988d8334e55