### PR TITLE
Allow setup wizard to auto-detect installation ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Next.js dashboard for roadmap-kit projects with **GitHub App auth** (PAT fallbac
 npm install
 cp .env.example .env.local
 # Fill ONE of the auth paths:
-# - GitHub App: GH_APP_ID, GH_APP_PRIVATE_KEY, (optional) GH_APP_INSTALLATION_ID
+# - GitHub App: GH_APP_ID, GH_APP_PRIVATE_KEY (GH_APP_INSTALLATION_ID optional; the wizard auto-detects when omitted)
 # - OR PAT: GITHUB_TOKEN with repo scope
 npm run dev
 ```
@@ -36,7 +36,7 @@ npm run dev
 ## Deploy (Vercel)
 
 Add env vars (Production + Preview):
-- **GitHub App**: `GH_APP_ID`, `GH_APP_PRIVATE_KEY`, `GH_APP_INSTALLATION_ID` (optional)
+- **GitHub App**: `GH_APP_ID`, `GH_APP_PRIVATE_KEY` (`GH_APP_INSTALLATION_ID` optional; the setup wizard will look it up)
 - or **PAT**: `GITHUB_TOKEN`
 - `READ_ONLY_CHECKS_URL` for the verify API
 - (optional) `GITHUB_WEBHOOK_SECRET` if you add a webhook

--- a/app/api/setup/route.ts
+++ b/app/api/setup/route.ts
@@ -59,7 +59,6 @@ export async function POST(req: NextRequest) {
   try {
     // If your getTokenForRepo reads different names, adjust here
     needEnv("GH_APP_ID");
-    needEnv("GH_APP_INSTALLATION_ID");
     // Accept either multiline PEM or base64
     if (!process.env.GH_APP_PRIVATE_KEY && !process.env.GH_APP_PRIVATE_KEY_B64) {
       throw new Error("Missing env: GH_APP_PRIVATE_KEY (or GH_APP_PRIVATE_KEY_B64)");
@@ -160,7 +159,8 @@ export async function POST(req: NextRequest) {
     } else if (/Not Found/i.test(msg) && /repos\/.*\/.*\/git/.test(msg)) {
       hint = "Owner/repo or branch is wrong, or the token doesn't have access.";
     } else if (/Bad credentials|401/i.test(msg)) {
-      hint = "App JWT or installation token failed—check GH_APP_ID / GH_APP_INSTALLATION_ID / private key.";
+      hint =
+        "App JWT or installation token failed—check GH_APP_ID / private key and make sure the app is installed on the repo.";
     } else if (/rate limit/i.test(msg)) {
       hint = "You’ve hit GitHub’s rate limit. Try again in a minute or use an App token instead of PAT.";
     }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -357,7 +357,7 @@ const SECRET_SNIPPET =
 const GITHUB_APP_ENV_SNIPPET = [
   "GH_APP_ID=<your-app-id>",
   'GH_APP_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\\n..."',
-  "# optional when multiple installations exist",
+  "# optional if you want to pin a specific installation",
   "GH_APP_INSTALLATION_ID=<installation-id>",
 ].join("\n");
 
@@ -1598,10 +1598,11 @@ function OnboardingChecklist({
             </pre>
           </details>
           <p className="onboarding-note">
-            Long term, deploy with the GitHub App credentials (and
-            <code>GH_APP_INSTALLATION_ID</code> if needed). For short tests you can temporarily make
-            the repository public or commit a generated <code>docs/roadmap-status.json</code>, but
-            those approaches leave the status API unable to reach private content.
+            Long term, deploy with the GitHub App credentials. The setup flow will auto-detect the
+            installation ID when <code>GH_APP_INSTALLATION_ID</code> is omitted, but you can provide
+            it to pin a specific installation. For short tests you can temporarily make the
+            repository public or commit a generated <code>docs/roadmap-status.json</code>, but those
+            approaches leave the status API unable to reach private content.
           </p>
         </li>
 


### PR DESCRIPTION
## Summary
- stop rejecting setup requests when `GH_APP_INSTALLATION_ID` is absent so the existing auto-detection path can run
- update onboarding UI and README guidance to explain the installation ID is optional and auto-detected

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db4220d82c832d8c0aaeae789939c2