### PR TITLE
Refine focus styles to avoid flash artifacts

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -15,14 +15,27 @@
 }
 *{ box-sizing:border-box; scrollbar-width:thin; scrollbar-color:rgba(78,161,255,0.35) transparent }
 html,body{ margin:0; padding:0; background:var(--bg); color:var(--fg); font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Arial; -webkit-tap-highlight-color:rgba(78,161,255,0.15) }
-:where(:not(html,body)):focus-visible{
-  outline:none;
-  box-shadow:0 0 0 2px rgba(78,161,255,0.6);
-  border-radius:8px;
-}
-:where(:not(html,body)):focus:not(:focus-visible){
-  outline:none;
+:where(button,
+       [role="button"],
+       [href],
+       input,
+       textarea,
+       select,
+       summary,
+       [tabindex]):focus-visible{
+  outline:2px solid rgba(78,161,255,0.7);
+  outline-offset:3px;
   box-shadow:none;
+}
+:where(button,
+       [role="button"],
+       [href],
+       input,
+       textarea,
+       select,
+       summary,
+       [tabindex]):focus:not(:focus-visible){
+  outline:none;
 }
 *::-webkit-scrollbar{ width:12px; height:12px }
 *::-webkit-scrollbar-track{ background:transparent }


### PR DESCRIPTION
## Summary
- scope the global focus-visible styles to interactive elements only
- switch focus indication to outline-based styling to prevent white flash artifacts during interaction

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68de15c9e7f4832d82fc641baa065024