### PR TITLE
Fix mid-project discovery launcher

### DIFF
--- a/app/api/brainstorm/chat/route.ts
+++ b/app/api/brainstorm/chat/route.ts
@@ -1,0 +1,117 @@
+import { NextResponse } from "next/server";
+import fs from "fs/promises";
+import path from "path";
+
+type ClientMessage = {
+  role: "user" | "assistant";
+  content: string;
+};
+
+type ChatRequestBody = {
+  conversationId?: string;
+  history?: ClientMessage[];
+  message?: string;
+};
+
+const SYSTEM_PROMPT =
+  "You are an ideation partner helping founders expand product ideas into detailed opportunities. " +
+  "Ask clarifying questions, suggest adjacent opportunities, and help them shape a concept into something actionable.";
+
+async function ensureIdeasFile(conversationId: string) {
+  const ideasDir = path.join("/tmp", "ideas");
+  await fs.mkdir(ideasDir, { recursive: true });
+  const filePath = path.join(ideasDir, `${conversationId}.md`);
+  try {
+    await fs.access(filePath);
+  } catch {
+    const header = `# Brainstorm Session ${conversationId}\n\n`;
+    await fs.writeFile(filePath, header, "utf8");
+  }
+  return filePath;
+}
+
+function normalizeHistory(history?: ClientMessage[]): ClientMessage[] {
+  if (!Array.isArray(history)) {
+    return [];
+  }
+
+  return history
+    .filter((message): message is ClientMessage => {
+      if (!message || typeof message !== "object") {
+        return false;
+      }
+      return (message.role === "user" || message.role === "assistant") && typeof message.content === "string";
+    })
+    .map((message) => ({
+      role: message.role,
+      content: message.content.trim(),
+    }));
+}
+
+export async function POST(req: Request) {
+  let body: ChatRequestBody;
+
+  try {
+    body = await req.json();
+  } catch (error) {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const openAiKey = process.env.OPENAI_API_KEY;
+
+  if (!openAiKey) {
+    return NextResponse.json({ error: "OpenAI API key is not configured" }, { status: 500 });
+  }
+
+  const history = normalizeHistory(body.history);
+  const userMessage = typeof body.message === "string" ? body.message.trim() : "";
+
+  if (!userMessage) {
+    return NextResponse.json({ error: "Message is required" }, { status: 400 });
+  }
+
+  const conversationId = body.conversationId?.trim() || Date.now().toString();
+
+  const payload = {
+    model: "gpt-4o-mini",
+    messages: [
+      { role: "system", content: SYSTEM_PROMPT },
+      ...history,
+      { role: "user", content: userMessage },
+    ],
+  };
+
+  const response = await fetch("https://api.openai.com/v1/chat/completions", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${openAiKey}`,
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    return NextResponse.json(
+      { error: "Failed to reach OpenAI", detail: errorText.slice(0, 400) },
+      { status: response.status },
+    );
+  }
+
+  const data = (await response.json()) as {
+    choices?: Array<{ message?: { content?: string } }>;
+  };
+
+  const reply = data.choices?.[0]?.message?.content?.trim();
+
+  if (!reply) {
+    return NextResponse.json({ error: "OpenAI response was empty" }, { status: 502 });
+  }
+
+  const filePath = await ensureIdeasFile(conversationId);
+  const timestamp = new Date().toISOString();
+  const entry = `## ${timestamp}\n\n### User\n${userMessage}\n\n### Assistant\n${reply}\n\n`;
+  await fs.appendFile(filePath, entry, "utf8");
+
+  return NextResponse.json({ conversationId, reply });
+}

--- a/app/api/brainstorm/promote/route.ts
+++ b/app/api/brainstorm/promote/route.ts
@@ -1,0 +1,85 @@
+import { NextResponse } from "next/server";
+import fs from "fs/promises";
+import path from "path";
+
+type ClientMessage = {
+  role: "user" | "assistant";
+  content: string;
+};
+
+type PromoteRequestBody = {
+  conversationId?: string;
+  messages?: ClientMessage[];
+};
+
+function normalizeMessages(messages?: ClientMessage[]): ClientMessage[] {
+  if (!Array.isArray(messages)) {
+    return [];
+  }
+
+  return messages
+    .filter((message): message is ClientMessage => {
+      if (!message || typeof message !== "object") {
+        return false;
+      }
+      return (message.role === "user" || message.role === "assistant") && typeof message.content === "string";
+    })
+    .map((message) => ({
+      role: message.role,
+      content: message.content.trim(),
+    }));
+}
+
+function formatTranscript(messages: ClientMessage[]): string {
+  return messages
+    .map((message, index) => {
+      const speaker = message.role === "user" ? "Founder" : "AI Partner";
+      const formattedContent = message.content.replace(/\n/g, "\n  ");
+      return `${index + 1}. **${speaker}:** ${formattedContent}`;
+    })
+    .join("\n");
+}
+
+export async function POST(req: Request) {
+  let body: PromoteRequestBody;
+
+  try {
+    body = await req.json();
+  } catch (error) {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const messages = normalizeMessages(body.messages);
+
+  if (messages.length === 0) {
+    return NextResponse.json({ error: "No messages to export" }, { status: 400 });
+  }
+
+  const conversationId = body.conversationId?.trim();
+  const timestamp = new Date().toISOString();
+
+  const docsDir = path.join(process.cwd(), "docs");
+  await fs.mkdir(docsDir, { recursive: true });
+  const ideaLogPath = path.join(docsDir, "idea-log.md");
+
+  let content = "";
+  try {
+    await fs.access(ideaLogPath);
+  } catch {
+    content += "# Idea Log\n\n";
+  }
+
+  const sessionHeaderParts = [
+    `## Session promoted on ${timestamp}`,
+    conversationId ? `Session ID: ${conversationId}` : undefined,
+    "",
+  ].filter(Boolean);
+
+  const transcript = formatTranscript(messages);
+
+  content += `${sessionHeaderParts.join("\n")}\n${transcript}\n\n`;
+
+  await fs.appendFile(ideaLogPath, content, "utf8");
+
+  return NextResponse.json({ ok: true, path: "docs/idea-log.md" });
+}

--- a/app/api/concept/commit/route.ts
+++ b/app/api/concept/commit/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from "next/server";
+
+import { putFile } from "@/lib/github";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function POST(req: Request) {
+  try {
+    const body = await req.json();
+    const owner = typeof body?.owner === "string" ? body.owner.trim() : "";
+    const repo = typeof body?.repo === "string" ? body.repo.trim() : "";
+    const branch = typeof body?.branch === "string" && body.branch.trim() ? body.branch.trim() : "main";
+    const content = typeof body?.content === "string" ? body.content : "";
+
+    if (!owner || !repo) {
+      return NextResponse.json({ error: "owner and repo are required" }, { status: 400 });
+    }
+
+    if (!content.trim()) {
+      return NextResponse.json({ error: "Roadmap content is empty" }, { status: 400 });
+    }
+
+    await putFile(owner, repo, "docs/roadmap.yml", content, branch, "feat(roadmap): add generated docs/roadmap.yml");
+
+    return NextResponse.json({ ok: true });
+  } catch (error: any) {
+    return NextResponse.json({ error: error?.message ?? "Failed to commit roadmap" }, { status: 500 });
+  }
+}

--- a/app/api/concept/generate/route.ts
+++ b/app/api/concept/generate/route.ts
@@ -1,0 +1,79 @@
+import { NextResponse } from "next/server";
+
+const SYSTEM_PROMPT = "Generate a YAML roadmap with weeks/items in docs/roadmap.yml format.";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+function normalizeInput(value: unknown): string {
+  if (typeof value === "string") {
+    return value.trim();
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry) => normalizeInput(entry)).filter(Boolean).join("\n\n");
+  }
+  if (value && typeof value === "object") {
+    return normalizeInput(Object.values(value));
+  }
+  return "";
+}
+
+export async function POST(req: Request) {
+  try {
+    const body = await req.json().catch(() => ({}));
+    const prompt = normalizeInput((body as { prompt?: unknown })?.prompt);
+
+    if (!prompt) {
+      return NextResponse.json({ error: "Provide concept text or an uploaded document" }, { status: 400 });
+    }
+
+    const apiKey = process.env.OPENAI_API_KEY;
+    if (!apiKey) {
+      return NextResponse.json({ error: "OpenAI API key is not configured" }, { status: 500 });
+    }
+
+    const payload = {
+      model: "gpt-4o-mini",
+      messages: [
+        { role: "system", content: SYSTEM_PROMPT },
+        {
+          role: "user",
+          content:
+            "Context from founder or product lead describing the concept. Generate docs/roadmap.yml YAML.\n\n" + prompt,
+        },
+      ],
+      temperature: 0.2,
+    };
+
+    const response = await fetch("https://api.openai.com/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      return NextResponse.json(
+        { error: "Failed to generate roadmap", detail: errorText.slice(0, 400) },
+        { status: response.status },
+      );
+    }
+
+    const data = (await response.json()) as {
+      choices?: Array<{ message?: { content?: string | null } }>;
+    };
+
+    const roadmap = data.choices?.[0]?.message?.content?.trim();
+
+    if (!roadmap) {
+      return NextResponse.json({ error: "OpenAI response was empty" }, { status: 502 });
+    }
+
+    return NextResponse.json({ roadmap });
+  } catch (error: any) {
+    return NextResponse.json({ error: error?.message ?? "Unexpected error" }, { status: 500 });
+  }
+}

--- a/app/api/discover/route.ts
+++ b/app/api/discover/route.ts
@@ -3,38 +3,174 @@ export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 import { NextRequest, NextResponse } from "next/server";
-import { getFileRaw, putFile } from "@/lib/github";
+import micromatch from "micromatch";
+import yaml from "js-yaml";
 
-// --- helpers ---
-async function probe(probeUrl: string, queries: string[]) {
-  if (!probeUrl) return queries.map(q => ({ q, ok: false, why: "no probeUrl" }));
-  const r = await fetch(probeUrl, {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({ queries })
-  });
-  if (!r.ok) return queries.map(q => ({ q, ok: false, why: String(r.status) }));
-  const j = await r.json().catch(() => ({}));
-  const arr = Array.isArray(j.results) ? j.results : [];
-  const byQ = new Map(arr.map((x: any) => [x.q, !!x.ok]));
-  return queries.map(q => ({ q, ok: !!byQ.get(q) }));
+import { getFileRaw, listRepoTree, putFile } from "@/lib/github";
+
+const READ_ONLY_CHECKS_URL = process.env.READ_ONLY_CHECKS_URL || "";
+
+const DEFAULT_DB_QUERIES = ["ext:pgcrypto"];
+const DEFAULT_CODE_GLOBS = ["src/screens/**/*.{tsx,ts}"];
+
+type ProbeResult = { q: string; ok: boolean; why?: string };
+type DiscoverConfig = {
+  db_queries: string[];
+  code_globs: string[];
+  notes: string[];
+};
+
+type BacklogItem = { id: string; title: string; status: "complete" };
+
+type DiscoverSummary = {
+  owner: string;
+  repo: string;
+  branch: string;
+  config: DiscoverConfig;
+  dbSuccesses: string[];
+  dbFailures: ProbeResult[];
+  matchedPaths: string[];
+  discovered: BacklogItem[];
+};
+
+function ensureStringList(value: unknown, fallback: string[]): string[] {
+  if (!Array.isArray(value)) return fallback;
+  const filtered = value
+    .map((item) => (typeof item === "string" ? item.trim() : ""))
+    .filter((item) => item.length > 0);
+  return filtered.length ? filtered : fallback;
 }
 
-async function fileExists(owner: string, repo: string, path: string, ref?: string) {
-  // We treat each path as literal (cheap existence check via contents API/raw)
-  const raw = await getFileRaw(owner, repo, path, ref).catch(() => null);
-  return raw !== null;
-}
-
-function yamlList(items: { id: string; title: string; status: "complete" }[]) {
-  if (!items.length) {
-    return "# Auto-discovered items that appear complete but weren’t on the roadmap\n# (none)\n";
+async function probeSupabase(queries: string[], overrideUrl?: string): Promise<ProbeResult[]> {
+  const url = overrideUrl?.trim() || READ_ONLY_CHECKS_URL;
+  if (!url) {
+    return queries.map((q) => ({ q, ok: false, why: "READ_ONLY_CHECKS_URL not configured" }));
   }
-  return (
-    ["# Auto-discovered items that appear complete but weren’t on the roadmap"]
-      .concat(items.map(x => `- id: ${x.id}\n  title: "${x.title}"\n  status: complete`))
-      .join("\n") + "\n"
+
+  try {
+    const response = await fetch(url, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ queries }),
+    });
+
+    if (!response.ok) {
+      return queries.map((q) => ({ q, ok: false, why: String(response.status) }));
+    }
+
+    const json = await response.json().catch(() => ({}));
+    const arr = Array.isArray(json?.results) ? json.results : [];
+    const byQuery = new Map(arr.map((entry: any) => [entry?.q, !!entry?.ok]));
+    return queries.map((q) => ({ q, ok: !!byQuery.get(q) }));
+  } catch (error: any) {
+    return queries.map((q) => ({ q, ok: false, why: error?.message || String(error) }));
+  }
+}
+
+function parseDiscoverConfig(raw: string | null): DiscoverConfig {
+  const notes: string[] = [];
+
+  if (!raw) {
+    notes.push("docs/discover.yml not found — using defaults");
+    return { db_queries: DEFAULT_DB_QUERIES, code_globs: DEFAULT_CODE_GLOBS, notes };
+  }
+
+  try {
+    const parsed = yaml.load(raw) as any;
+    const dbQueries = ensureStringList(parsed?.db_queries ?? parsed?.dbQueries, DEFAULT_DB_QUERIES);
+    const codeGlobs = ensureStringList(parsed?.code_globs ?? parsed?.codeGlobs, DEFAULT_CODE_GLOBS);
+    return { db_queries: dbQueries, code_globs: codeGlobs, notes };
+  } catch (error: any) {
+    notes.push(`Failed to parse docs/discover.yml (${error?.message || String(error)})`);
+    return { db_queries: DEFAULT_DB_QUERIES, code_globs: DEFAULT_CODE_GLOBS, notes };
+  }
+}
+
+function slugify(input: string) {
+  return input
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 64) || "item";
+}
+
+function backlogYaml(items: BacklogItem[]) {
+  if (!items.length) {
+    return [
+      "# Auto-discovered items generated from docs/discover.yml",
+      "# (none detected)",
+      "",
+    ].join("\n");
+  }
+
+  return [
+    "# Auto-discovered items generated from docs/discover.yml",
+    ...items.map((item) => `- id: ${item.id}\n  title: "${item.title.replace(/"/g, '\\"')}"\n  status: complete`),
+    "",
+  ].join("\n");
+}
+
+function buildSummary(details: DiscoverSummary) {
+  const { owner, repo, branch, config, dbSuccesses, dbFailures, matchedPaths, discovered } = details;
+  const lines: string[] = [
+    `Repo: ${owner}/${repo}`,
+    `Branch: ${branch}`,
+    `Generated: ${new Date().toISOString()}`,
+    "",
+    "Discovery configuration:",
+    `- db_queries (${config.db_queries.length}): ${config.db_queries.join(", ") || "(none)"}`,
+    `- code_globs (${config.code_globs.length}): ${config.code_globs.join(", ") || "(none)"}`,
+  ];
+
+  if (config.notes.length) {
+    lines.push("", "Notes:", ...config.notes.map((note) => `- ${note}`));
+  }
+
+  lines.push(
+    "",
+    `Successful database probes (${dbSuccesses.length}):`,
+    dbSuccesses.length ? dbSuccesses.map((q) => `- ${q}`).join("\n") : "- none",
+    "",
+    `Failed database probes (${dbFailures.length}):`,
+    dbFailures.length ? dbFailures.map((r) => `- ${r.q}${r.why ? ` → ${r.why}` : ""}`).join("\n") : "- none",
+    "",
+    `Matched code paths (${matchedPaths.length}):`,
+    matchedPaths.length ? matchedPaths.map((path) => `- ${path}`).join("\n") : "- none",
+    "",
+    `Newly discovered backlog items (${discovered.length}):`,
+    discovered.length ? discovered.map((item) => `- ${item.title}`).join("\n") : "- none",
+    "",
   );
+
+  return lines.join("\n");
+}
+
+function alreadyTrackedFactory(doneNames: Set<string>) {
+  const comparisons = Array.from(doneNames)
+    .map((name) => name.toLowerCase())
+    .filter(Boolean);
+
+  return (title: string) => {
+    const lower = title.toLowerCase();
+    return comparisons.some((name) => lower === name || lower.includes(name));
+  };
+}
+
+async function safePut(
+  owner: string,
+  repo: string,
+  branch: string,
+  path: string,
+  content: string,
+  message: string,
+  wrote: string[],
+) {
+  try {
+    await putFile(owner, repo, path, content, branch, message);
+    wrote.push(path);
+  } catch (error: any) {
+    wrote.push(`${path} (FAILED: ${error?.message || String(error)})`);
+  }
 }
 
 export async function POST(req: NextRequest) {
@@ -44,85 +180,88 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: "missing owner/repo" }, { status: 400 });
     }
 
-    // 1) Read current status to avoid duplicating already-done items
     const statusRaw = await getFileRaw(owner, repo, "docs/roadmap-status.json", branch).catch(() => null);
     const doneNames = new Set<string>();
     if (statusRaw) {
       try {
-        const s = JSON.parse(statusRaw);
-        for (const w of s.weeks ?? []) {
-          for (const it of w.items ?? []) {
-            if (it?.done && typeof it?.name === "string") doneNames.add(it.name);
+        const parsed = JSON.parse(statusRaw);
+        for (const week of parsed?.weeks ?? []) {
+          for (const item of week?.items ?? []) {
+            if (item?.done && typeof item?.name === "string") {
+              doneNames.add(item.name);
+            }
           }
         }
       } catch {}
     }
 
-    // 2) DB probes (edit this list to fit your schema/policies)
-    const dbQueries = [
-      "ext:pgcrypto",
-      "table:public:profiles",
-      "rls:public:profiles",
-      // Example policy (rename to match your policy names):
-      "policy:public:profiles:select:Profiles can view own"
-    ];
-    const db = await probe(probeUrl, dbQueries);
+    const discoverRaw = await getFileRaw(owner, repo, "docs/discover.yml", branch).catch(() => null);
+    const config = parseDiscoverConfig(discoverRaw);
 
-    // 3) Code presence checks (add paths that matter for your repos)
-    const codePaths = [
-      "supabase/functions/read_only_checks/index.ts",
-      "src/screens/JournalScreen.tsx",
-      "docs/context/context-pack.json",
-      "docs/tech-stack.yml"
-    ];
-    const present: string[] = [];
-    for (const p of codePaths) {
-      // eslint-disable-next-line no-await-in-loop
-      if (await fileExists(owner, repo, p, branch)) present.push(p);
-    }
+    const dbResults = await probeSupabase(config.db_queries, probeUrl);
+    const dbSuccesses = dbResults.filter((result) => result.ok).map((result) => result.q);
+    const dbFailures = dbResults.filter((result) => !result.ok);
 
-    // 4) Build discovered list, skipping names already “done” in status
-    const discovered: { id: string; title: string; status: "complete" }[] = [];
+    const treePaths = await listRepoTree(owner, repo, branch);
+    const matchedPaths = config.code_globs.length
+      ? Array.from(new Set(micromatch(treePaths, config.code_globs, { dot: true }))).sort()
+      : [];
 
-    for (const r of db) {
-      if (r.ok) {
-        const title = `DB: ${r.q}`;
-        if (![...doneNames].some(n => title.includes(n))) {
-          discovered.push({ id: r.q.replace(/[^a-zA-Z0-9_-]+/g, "-"), title, status: "complete" });
-        }
-      }
-    }
-    for (const p of present) {
-      const title = `Code: ${p} present`;
-      if (![...doneNames].some(n => title.includes(n))) {
-        discovered.push({ id: p.replace(/[^a-zA-Z0-9_-]+/g, "-"), title, status: "complete" });
+    const alreadyTracked = alreadyTrackedFactory(doneNames);
+    const discovered: BacklogItem[] = [];
+
+    for (const query of dbSuccesses) {
+      const title = `Database check present: ${query}`;
+      if (!alreadyTracked(title)) {
+        discovered.push({ id: slugify(`db-${query}`), title, status: "complete" });
       }
     }
 
-    // 5) Commit artifacts
+    for (const path of matchedPaths) {
+      const title = `Code path matched: ${path}`;
+      if (!alreadyTracked(title)) {
+        discovered.push({ id: slugify(`code-${path}`), title, status: "complete" });
+      }
+    }
+
     const wrote: string[] = [];
-    async function safePut(path: string, content: string, msg: string) {
-      try {
-        await putFile(owner, repo, path, content, branch, msg);
-        wrote.push(path);
-      } catch (e: any) {
-        wrote.push(`${path} (FAILED: ${e?.message || e})`);
-      }
-    }
 
-    const backlogBody = yamlList(discovered);
-    await safePut("docs/backlog-discovered.yml", backlogBody, "chore(roadmap): update backlog-discovered [skip ci]");
+    await safePut(
+      owner,
+      repo,
+      branch,
+      "docs/backlog-discovered.yml",
+      backlogYaml(discovered),
+      "chore(roadmap): update backlog-discovered [skip ci]",
+      wrote,
+    );
 
-    const summary = `Repo: ${owner}/${repo}
-Generated: ${new Date().toISOString()}
+    const summary = buildSummary({
+      owner,
+      repo,
+      branch,
+      config,
+      dbSuccesses,
+      dbFailures,
+      matchedPaths,
+      discovered,
+    });
 
-Newly discovered, already-done items (not on roadmap):
-${discovered.length ? discovered.map(d => `- ${d.title}`).join("\n") : "- none"}
-`;
-    await safePut("docs/summary.txt", summary, "chore(roadmap): update summary [skip ci]");
+    await safePut(owner, repo, branch, "docs/summary.txt", summary, "chore(roadmap): update summary [skip ci]", wrote);
 
-    return NextResponse.json({ ok: true, discovered: discovered.length, wrote }, { headers: { "cache-control": "no-store" } });
-  } catch (e: any) {
-    return NextResponse.json({ error: String(e?.message || e) }, { status: 500 });
+    return NextResponse.json(
+      {
+        ok: true,
+        discovered: discovered.length,
+        items: discovered,
+        wrote,
+        config,
+        db: dbResults,
+        code_matches: matchedPaths,
+      },
+      { headers: { "cache-control": "no-store" } },
+    );
+  } catch (error: any) {
+    return NextResponse.json({ error: String(error?.message || error) }, { status: 500 });
   }
 }

--- a/app/api/roadmap/import/route.ts
+++ b/app/api/roadmap/import/route.ts
@@ -1,0 +1,162 @@
+import { NextResponse } from "next/server";
+import { load } from "js-yaml";
+
+import { getFileRaw, putFile } from "@/lib/github";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const INFRA_FACTS_TEMPLATE = [
+  "# Infrastructure facts",
+  "",
+  "- **Primary environment**: ",
+  "- **Database**: ",
+  "- **Deployment pipeline**: ",
+  "- **Monitoring & alerts**: ",
+  "",
+  "Add infra constraints, compliance requirements, and escalation paths so the build team ships with confidence.",
+  "",
+].join("\n");
+
+const TECH_STACK_TEMPLATE = [
+  "version: 1",
+  "stack:",
+  "  frontend:",
+  "    frameworks: []",
+  "    libraries: []",
+  "  backend:",
+  "    languages: []",
+  "    services: []",
+  "  infrastructure:",
+  "    platforms: []",
+  "    observability: []",
+  "integrations: []",
+  "notes: []",
+  "",
+].join("\n");
+
+const ROADMAP_WORKFLOW_TEMPLATE = [
+  "name: Roadmap checks",
+  "on:",
+  "  push:",
+  "    branches: [main]",
+  "  pull_request:",
+  "jobs:",
+  "  roadmap:",
+  "    runs-on: ubuntu-latest",
+  "    steps:",
+  "      - uses: actions/checkout@v4",
+  "      - uses: actions/setup-node@v4",
+  "        with:",
+  "          node-version: 20",
+  "      - run: npm ci",
+  "      - run: npm run roadmap:check",
+  "        env:",
+  "          READ_ONLY_CHECKS_URL: ${{ secrets.READ_ONLY_CHECKS_URL }}",
+  "",
+].join("\n");
+
+type ImportRequestBody = {
+  owner?: string;
+  repo?: string;
+  branch?: string;
+  roadmap?: string;
+};
+
+type ImportSuccess = {
+  ok: true;
+  created: string[];
+  skipped: string[];
+};
+
+type ImportError = {
+  error: string;
+  detail?: string;
+};
+
+export async function POST(req: Request) {
+  let body: ImportRequestBody;
+  try {
+    body = (await req.json()) as ImportRequestBody;
+  } catch (error) {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const owner = typeof body?.owner === "string" ? body.owner.trim() : "";
+  const repo = typeof body?.repo === "string" ? body.repo.trim() : "";
+  const branch = typeof body?.branch === "string" && body.branch.trim() ? body.branch.trim() : "main";
+  const roadmap = typeof body?.roadmap === "string" ? body.roadmap : "";
+
+  if (!owner || !repo) {
+    return NextResponse.json({ error: "owner and repo are required" }, { status: 400 });
+  }
+
+  if (!roadmap.trim()) {
+    return NextResponse.json({ error: "Roadmap file is empty" }, { status: 400 });
+  }
+
+  try {
+    const parsed = load(roadmap);
+    if (!parsed || typeof parsed !== "object") {
+      return NextResponse.json({ error: "docs/roadmap.yml must parse into an object" }, { status: 400 });
+    }
+  } catch (error: any) {
+    return NextResponse.json(
+      { error: "Failed to parse roadmap.yml", detail: error?.message ?? String(error) },
+      { status: 400 },
+    );
+  }
+
+  const created: string[] = [];
+  const skipped: string[] = [];
+
+  try {
+    await putFile(
+      owner,
+      repo,
+      "docs/roadmap.yml",
+      roadmap,
+      branch,
+      "feat(roadmap): import roadmap definition",
+    );
+    created.push("docs/roadmap.yml");
+
+    const scaffoldTargets = [
+      {
+        path: "docs/infra-facts.md",
+        content: INFRA_FACTS_TEMPLATE,
+        message: "chore(roadmap): scaffold docs/infra-facts.md",
+      },
+      {
+        path: "docs/tech-stack.yml",
+        content: TECH_STACK_TEMPLATE,
+        message: "chore(roadmap): scaffold docs/tech-stack.yml",
+      },
+      {
+        path: ".github/workflows/roadmap.yml",
+        content: ROADMAP_WORKFLOW_TEMPLATE,
+        message: "chore(roadmap): add roadmap workflow",
+      },
+    ] as const;
+
+    for (const target of scaffoldTargets) {
+      const existing = await getFileRaw(owner, repo, target.path, branch);
+
+      if (existing !== null) {
+        skipped.push(target.path);
+        continue;
+      }
+
+      await putFile(owner, repo, target.path, target.content, branch, target.message);
+      created.push(target.path);
+    }
+
+    const response: ImportSuccess = { ok: true, created, skipped };
+    return NextResponse.json(response);
+  } catch (error: any) {
+    const payload: ImportError = {
+      error: error?.message ?? "Failed to import roadmap",
+    };
+    return NextResponse.json(payload, { status: 500 });
+  }
+}

--- a/app/api/status/[owner]/[repo]/route.ts
+++ b/app/api/status/[owner]/[repo]/route.ts
@@ -1,8 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getFileRaw } from "@/lib/github";
-export async function GET(_req:NextRequest, { params }:{ params:{ owner:string; repo:string }}) {
+
+export async function GET(req: NextRequest, { params }: { params: { owner: string; repo: string } }) {
   try {
-    const raw = await getFileRaw(params.owner, params.repo, "docs/roadmap-status.json").catch(()=>null);
+    const url = new URL(req.url);
+    const branch = url.searchParams.get("branch") || undefined;
+    const raw = await getFileRaw(params.owner, params.repo, "docs/roadmap-status.json", branch).catch(() => null);
     if (!raw) return NextResponse.json({ error:"not_found" }, { status:404 });
     return NextResponse.json(JSON.parse(raw));
   } catch (e:any) {

--- a/app/globals.css
+++ b/app/globals.css
@@ -246,6 +246,101 @@ button.ghost-button:disabled{ opacity:0.6; cursor:not-allowed; background:transp
 .add-project-actions .project-wizard{ font-size:14px }
 .add-project-hints{ margin:0; padding-left:18px; display:grid; gap:6px; font-size:13px; color:var(--muted) }
 .add-project-hints code{ font-size:12px }
+.add-project-wizard{ display:grid; gap:12px }
+.add-project-wizard h3{ margin:0; font-size:16px; color:#cfe2f3 }
+.add-project-wizard p{ margin:0; font-size:14px; line-height:1.5; color:var(--muted) }
+.add-project-wizard-grid{ display:grid; gap:12px; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)) }
+.add-project-wizard-card{ display:grid; gap:12px; padding:16px; border-radius:14px; border:1px solid #1f2732; background:rgba(12,18,28,0.85); transition:border-color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease; color:inherit; cursor:pointer; outline:none }
+.add-project-wizard-card:hover{ border-color:rgba(78,161,255,0.55); transform:translateY(-2px); box-shadow:0 12px 26px rgba(10,15,24,0.45) }
+.add-project-wizard-card:focus-visible{ border-color:rgba(148,205,255,0.85); box-shadow:0 0 0 3px rgba(78,161,255,0.3) }
+.add-project-wizard-card h4{ margin:0; font-size:16px; color:var(--fg) }
+.add-project-wizard-card p{ margin:0; font-size:14px; line-height:1.55; color:var(--muted) }
+.add-project-wizard-card ul{ margin:0; padding-left:18px; display:grid; gap:6px; font-size:13px; color:var(--muted) }
+.add-project-wizard-copy{ display:grid; gap:6px }
+.add-project-wizard-meta{ display:flex; align-items:center; gap:8px; font-size:12px; text-transform:uppercase; letter-spacing:0.08em; color:var(--muted) }
+.add-project-wizard-label{ display:inline-flex; align-items:center; justify-content:center; padding:4px 10px; border-radius:999px; border:1px solid #283042; background:rgba(15,21,32,0.75); color:var(--fg); font-size:11px; font-weight:600 }
+.add-project-wizard-sub{ font-size:11px; color:var(--muted) }
+.add-project-wizard-actions{ display:flex; flex-wrap:wrap; gap:8px }
+.add-project-wizard-action{ display:inline-flex; align-items:center; gap:6px; padding:6px 12px; border-radius:999px; border:1px solid #273244; background:rgba(18,26,38,0.95); color:var(--fg); font-size:13px; font-weight:600; text-decoration:none; transition:background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease }
+.add-project-wizard-action:hover{ border-color:rgba(78,161,255,0.45); color:#e6f0ff }
+.add-project-wizard-action--primary{ background:rgba(219,234,254,0.9); color:#0f172a; border-color:rgba(219,234,254,0.9) }
+.add-project-wizard-action--primary:hover{ background:#e8f1ff; color:#0b1220; border-color:#e8f1ff }
+.add-project-wizard-note{ margin:0; font-size:12px; line-height:1.5; color:rgba(167,197,255,0.85) }
 
 @media (min-width:560px){ .project-form-row{ grid-template-columns:repeat(2,minmax(0,1fr)) } }
 @media (max-width:980px){ .dashboard-shell{ grid-template-columns:1fr } .project-panel{ position:relative; top:auto; max-height:none; overflow:visible } .project-panel-body{ width:100%; margin-right:0; padding-right:0; overflow:visible } }
+
+/* Minimal Tailwind-inspired utilities for the wizard UI */
+.tw-space-y-10 > * + * { margin-top: 2.5rem; }
+.tw-space-y-3 > * + * { margin-top: 0.75rem; }
+.tw-space-y-2 > * + * { margin-top: 0.5rem; }
+.tw-inline-flex { display: inline-flex; }
+.tw-flex { display: flex; }
+.tw-grid { display: grid; }
+.tw-flex-col { flex-direction: column; }
+.tw-flex-wrap { flex-wrap: wrap; }
+.tw-items-center { align-items: center; }
+.tw-items-start { align-items: flex-start; }
+.tw-justify-center { justify-content: center; }
+.tw-gap-2 { gap: 0.5rem; }
+.tw-gap-3 { gap: 0.75rem; }
+.tw-gap-4 { gap: 1rem; }
+.tw-gap-6 { gap: 1.5rem; }
+.tw-gap-10 { gap: 2.5rem; }
+.tw-rounded-full { border-radius: 9999px; }
+.tw-rounded-3xl { border-radius: 1.5rem; }
+.tw-border { border: 1px solid rgba(148, 163, 184, 0.25); }
+.tw-border-slate-800 { border-color: rgba(30, 41, 59, 0.75); }
+.tw-px-3 { padding-left: 0.75rem; padding-right: 0.75rem; }
+.tw-py-1 { padding-top: 0.25rem; padding-bottom: 0.25rem; }
+.tw-p-6 { padding: 1.5rem; }
+.tw-p-8 { padding: 2rem; }
+.tw-text-xs { font-size: 0.75rem; line-height: 1rem; }
+.tw-text-sm { font-size: 0.875rem; line-height: 1.5rem; }
+.tw-text-lg { font-size: 1.125rem; line-height: 1.75rem; }
+.tw-text-xl { font-size: 1.25rem; line-height: 1.75rem; }
+.tw-text-2xl { font-size: 1.5rem; line-height: 2rem; }
+.tw-text-3xl { font-size: 1.875rem; line-height: 2.25rem; }
+.tw-text-\[0\.7rem\] { font-size: 0.7rem; line-height: 1rem; }
+.tw-font-medium { font-weight: 500; }
+.tw-font-semibold { font-weight: 600; }
+.tw-font-bold { font-weight: 700; }
+.tw-uppercase { text-transform: uppercase; }
+.tw-tracking-wide { letter-spacing: 0.12em; }
+.tw-text-slate-100 { color: #e2e8f0; }
+.tw-text-slate-300 { color: #94a3b8; }
+.tw-text-slate-400 { color: #7c8a9f; }
+.tw-leading-tight { line-height: 1.2; }
+.tw-leading-snug { line-height: 1.35; }
+.tw-leading-relaxed { line-height: 1.6; }
+.tw-h-full { height: 100%; }
+.tw-bg-slate-900 { background-color: rgba(15, 23, 42, 0.85); }
+.tw-transition { transition-property: all; }
+.tw-duration-200 { transition-duration: 200ms; }
+.tw-ease-out { transition-timing-function: cubic-bezier(0, 0, 0.2, 1); }
+.tw-transform { transform: translateZ(0); }
+.tw-list-disc { list-style: disc; }
+.tw-pl-5 { padding-left: 1.25rem; }
+.tw-block { display: block; }
+.tw-mb-6 { margin-bottom: 1.5rem; }
+
+.hover\:tw-border-slate-700:hover { border-color: rgba(51, 65, 85, 0.8); }
+.hover\:tw-shadow-xl:hover { box-shadow: 0 24px 60px rgba(8, 15, 30, 0.45); }
+.hover\:tw-translate-y-\[-4px\]:hover { transform: translateY(-4px); }
+.hover\:tw-text-slate-100:hover { color: #e2e8f0; }
+
+.md\:tw-grid-cols-2 { grid-template-columns: repeat(1, minmax(0, 1fr)); }
+@media (min-width: 768px) {
+  .md\:tw-grid-cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+}
+
+.code-editor{ position:relative; border-radius:18px; border:1px solid rgba(51,65,85,0.55); background:rgba(8,12,18,0.85); overflow:hidden; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace; }
+.code-editor__preview{ margin:0; padding:18px; white-space:pre; overflow:auto; max-height:420px; color:#e7eef7; pointer-events:none; }
+.code-editor__textarea{ position:absolute; inset:0; resize:none; padding:18px; border:none; background:transparent; color:transparent; caret-color:#f8fafc; font: inherit; line-height:1.5; tab-size:2; outline:none; overflow:auto; }
+.code-editor__textarea::selection{ background:rgba(148,163,184,0.25); }
+.token-key{ color:#93c5fd; font-weight:600; }
+.token-colon{ color:#7dd3fc; }
+.token-string{ color:#fcd34d; }
+.token-comment{ color:#94a3b8; font-style:italic; }
+.token-dash{ color:#f472b6; }
+

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,9 +1,10 @@
-import './globals.css';
-import React from 'react';
+import "./globals.css";
+import Link from "next/link";
+import React from "react";
 
 export const metadata = {
-  title: 'Roadmap Dashboard Pro',
-  description: 'Continuous context dashboard for roadmap-kit projects (GitHub App ready)'
+  title: "Roadmap Dashboard Pro",
+  description: "Continuous context dashboard for roadmap-kit projects (GitHub App ready)",
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
@@ -11,9 +12,28 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     <html lang="en">
       <body>
         <div className="container">
-          <h1>🚀 Roadmap Dashboard Pro</h1>
-          <div className="hint">Onboard repos, view status, edit rc, and verify infra — safely.</div>
-          <div style={{height:10}} />
+          <header className="tw-flex tw-flex-col tw-gap-4 tw-mb-6">
+            <div className="tw-flex tw-flex-wrap tw-items-start tw-justify-between tw-gap-4">
+              <div className="tw-space-y-2">
+                <h1>🚀 Roadmap Dashboard Pro</h1>
+                <div className="hint">Onboard repos, view status, edit rc, and verify infra — safely.</div>
+              </div>
+              <nav className="tw-inline-flex tw-flex-wrap tw-gap-2">
+                <Link
+                  href="/"
+                  className="tw-inline-flex tw-items-center tw-gap-2 tw-rounded-full tw-border tw-border-slate-800 tw-px-3 tw-py-1 tw-text-sm tw-font-medium tw-text-slate-300 tw-transition tw-duration-200 tw-ease-out hover:tw-border-slate-700 hover:tw-text-slate-100"
+                >
+                  <span>Dashboard</span>
+                </Link>
+                <Link
+                  href="/wizard"
+                  className="tw-inline-flex tw-items-center tw-gap-2 tw-rounded-full tw-border tw-border-slate-800 tw-px-3 tw-py-1 tw-text-sm tw-font-medium tw-text-slate-300 tw-transition tw-duration-200 tw-ease-out hover:tw-border-slate-700 hover:tw-text-slate-100"
+                >
+                  <span>Add New Project</span>
+                </Link>
+              </nav>
+            </div>
+          </header>
           {children}
         </div>
       </body>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,9 +1,21 @@
 "use client";
 
-import { Suspense, type FormEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import Link from "next/link";
+import {
+  Suspense,
+  type FormEvent,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type MouseEvent as ReactMouseEvent,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 
 import { ROADMAP_CHECKER_SNIPPET } from "@/lib/roadmap-snippets";
+import { WIZARD_ENTRY_POINTS, type WizardEntryPoint } from "@/lib/wizard-entry-points";
 
 type Check = {
   id?: string;
@@ -1261,17 +1273,15 @@ function ProjectSidebar({
   );
 }
 
-function AddProjectTab({
-  onAdd,
-  onSelect,
-  wizardHref,
-  hasProjects,
-}: {
+type AddProjectTabProps = {
   onAdd: (repo: RepoRef) => RepoRef | null;
   onSelect?: (repo: RepoRef) => void;
   wizardHref: string;
   hasProjects: boolean;
-}) {
+};
+
+function AddProjectTab(props: AddProjectTabProps) {
+  const { onAdd, onSelect, wizardHref, hasProjects } = props;
   return (
     <section className="card add-project-card">
       <div className="add-project-header">
@@ -1287,6 +1297,18 @@ function AddProjectTab({
         </a>
         <p className="hint">The wizard walks through secrets, workflows, and Supabase setup for a fresh project.</p>
       </div>
+      <div className="add-project-wizard">
+        <h3>Choose a guided workflow</h3>
+        <p>
+          Match the onboarding wizard to your current milestone. Jump into the playbook for an overview or launch the workspace tools
+          directly when you are ready to build.
+        </p>
+        <div className="add-project-wizard-grid">
+          {WIZARD_ENTRY_POINTS.map((entry) => (
+            <WizardEntryCard key={entry.slug} entry={entry} />
+          ))}
+        </div>
+      </div>
       <ProjectForm onAdd={onAdd} onSelect={onSelect} className="project-form" submitLabel="Save project" />
       <ul className="add-project-hints">
         <li>Use owner/repo to add quickly, e.g. <code>acme-co/roadmap</code>.</li>
@@ -1294,6 +1316,78 @@ function AddProjectTab({
         {hasProjects ? null : <li>Your first project will also appear in the sidebar for quick access.</li>}
       </ul>
     </section>
+  );
+}
+
+function WizardEntryCard({ entry }: { entry: WizardEntryPoint }) {
+  const router = useRouter();
+
+  const handleNavigate = useCallback(() => {
+    router.push(`/wizard/${entry.slug}`);
+  }, [entry.slug, router]);
+
+  const handleKeyDown = useCallback(
+    (event: ReactKeyboardEvent<HTMLDivElement>) => {
+      if (event.key === "Enter" || event.key === " ") {
+        event.preventDefault();
+        handleNavigate();
+      }
+    },
+    [handleNavigate],
+  );
+
+  const stopPropagation = useCallback((event: ReactMouseEvent<HTMLElement>) => {
+    event.stopPropagation();
+  }, []);
+
+  return (
+    <article
+      role="button"
+      tabIndex={0}
+      className="add-project-wizard-card"
+      onClick={handleNavigate}
+      onKeyDown={handleKeyDown}
+    >
+      <div className="add-project-wizard-meta">
+        <span className="add-project-wizard-label">{entry.label}</span>
+        <span className="add-project-wizard-sub">Entry point</span>
+      </div>
+      <div className="add-project-wizard-copy">
+        <h4>{entry.title}</h4>
+        <p>{entry.description}</p>
+      </div>
+      <ul>
+        {entry.bullets.map((bullet) => (
+          <li key={bullet}>{bullet}</li>
+        ))}
+      </ul>
+      <div className="add-project-wizard-actions">
+        <Link
+          href={`/wizard/${entry.slug}`}
+          className="add-project-wizard-action add-project-wizard-action--primary"
+          onClick={stopPropagation}
+        >
+          View playbook
+        </Link>
+        {entry.tools?.map((tool) => (
+          <Link
+            key={tool.href}
+            href={tool.href}
+            className="add-project-wizard-action"
+            onClick={stopPropagation}
+          >
+            {tool.label}
+          </Link>
+        ))}
+      </div>
+      {entry.tools?.map((tool) =>
+        tool.description ? (
+          <p key={`${tool.href}-note`} className="add-project-wizard-note">
+            {tool.description}
+          </p>
+        ) : null
+      )}
+    </article>
   );
 }
 

--- a/app/wizard/[state]/page.tsx
+++ b/app/wizard/[state]/page.tsx
@@ -1,0 +1,443 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+type StageTool = {
+  href: string;
+  label: string;
+  description?: string;
+};
+
+type StageConfig = {
+  label: string;
+  title: string;
+  description: string;
+  cta?: {
+    eyebrow: string;
+    title: string;
+    description: string;
+    action: { href: string; label: string };
+    note: string;
+  };
+  sections: {
+    id: string;
+    title: string;
+    summary: string;
+    checklist: { title: string; detail: string }[];
+  }[];
+  resources: { label: string; href: string }[];
+  tools?: StageTool[];
+};
+
+const STAGES = {
+  "new-idea": {
+    label: "Ideation",
+    title: "New Idea Brainstorming",
+    description:
+      "Capture and expand every spark with a persistent AI workspace that keeps your ideas tethered to future execution.",
+    cta: {
+      eyebrow: "Live AI workspace",
+      title: "Jump into the brainstorming chat",
+      description:
+        "Spin up the connected ideation thread so every idea, insight, and follow-up question stays linked to this project.",
+      action: {
+        href: "/wizard/brainstorm",
+        label: "Launch idea workspace",
+      },
+      note: "Opens the interactive chat where each turn is saved to /tmp/ideas and can be promoted into docs/idea-log.md.",
+    },
+    tools: [
+      {
+        href: "/wizard/brainstorm",
+        label: "Launch idea workspace",
+        description:
+          "Open the AI chat that logs every turn and can be promoted into docs/idea-log.md.",
+      },
+    ],
+    sections: [
+      {
+        id: "canvas",
+        title: "Spin up your idea canvas",
+        summary:
+          "Start a connected chat workspace and define the problem, audience, and success signals before you rush into solutions.",
+        checklist: [
+          {
+            title: "Create a linked AI thread",
+            detail:
+              "Launch a project chat that stores history and can be promoted into a roadmap when you are ready to commit.",
+          },
+          {
+            title: "Map the opportunity",
+            detail:
+              "Outline core jobs-to-be-done, constraints, and differentiators. Drop links, voice notes, or sketches directly into the canvas.",
+          },
+          {
+            title: "Mark open questions",
+            detail:
+              "Flag unknowns for future discovery so the roadmap wizard can track research tasks alongside build work.",
+          },
+        ],
+      },
+      {
+        id: "transition",
+        title: "Get roadmap-ready",
+        summary:
+          "When the concept firms up, promote the session into a draft roadmap without losing any of the conversational context.",
+        checklist: [
+          {
+            title: "Highlight must-have outcomes",
+            detail: "Convert promising notes into roadmap epics with draft success metrics.",
+          },
+          {
+            title: "Attach reference material",
+            detail: "Upload PDFs, competitor teardowns, or market research so execution always stays grounded in your insight.",
+          },
+          {
+            title: "Review with collaborators",
+            detail: "Share the board or export a brief for feedback before moving into the build planning flow.",
+          },
+        ],
+      },
+    ],
+    resources: [
+      { label: "Back to wizard", href: "/wizard" },
+      { label: "Launch idea workspace", href: "/wizard/brainstorm" },
+    ],
+  },
+  concept: {
+    label: "Roadmap Drafting",
+    title: "Firm Concept, Missing Roadmap",
+    description:
+      "Turn your concept brief into an actionable roadmap, complete with generated project files, integrations, and automation hooks.",
+    cta: {
+      eyebrow: "Roadmap workspace",
+      title: "Draft docs/roadmap.yml from your brief",
+      description:
+        "Open the guided flow to paste concept notes, upload supporting files, and generate a YAML roadmap before committing it to your repo.",
+      action: {
+        href: "/wizard/concept/workspace",
+        label: "Open roadmap drafting workspace",
+      },
+      note: "Launches the upload + AI generation experience with repo commit controls.",
+    },
+    tools: [
+      {
+        href: "/wizard/concept/workspace",
+        label: "Open roadmap drafting workspace",
+        description:
+          "Paste your brief or upload a file, generate docs/roadmap.yml, and commit it to the repo.",
+      },
+    ],
+    sections: [
+      {
+        id: "ingest",
+        title: "Import and align context",
+        summary:
+          "Upload your concept doc or pull in an existing AI conversation so the wizard understands scope, goals, and guardrails.",
+        checklist: [
+          {
+            title: "Link supporting chats",
+            detail: "Attach brainstorming threads so the assistant can reference prior thinking during roadmap generation.",
+          },
+          {
+            title: "Clarify constraints",
+            detail: "Call out timelines, team capacity, and tech stack preferences so the plan reflects reality.",
+          },
+          {
+            title: "Set success metrics",
+            detail: "Define the signals that tell you the launch worked — adoption, revenue, activation, or retention goals.",
+          },
+        ],
+      },
+      {
+        id: "scaffold",
+        title: "Generate the execution scaffold",
+        summary:
+          "Translate the concept into docs/roadmap.yml, docs/gtm-plan.md, and integration-ready placeholders with one click.",
+        checklist: [
+          {
+            title: "Draft roadmap milestones",
+            detail: "Let the wizard propose weeks, owners, and deliverables that you can edit before publishing.",
+          },
+          {
+            title: "Configure integrations",
+            detail: "Paste Supabase and GitHub secrets so automated status checks can run from day one.",
+          },
+          {
+            title: "Push to your repo",
+            detail: "Export the scaffold into your workspace and open a PR for teammates to review.",
+          },
+        ],
+      },
+    ],
+    resources: [
+      { label: "Back to wizard", href: "/wizard" },
+      { label: "Open roadmap drafting workspace", href: "/wizard/concept/workspace" },
+    ],
+  },
+  "roadmap-ready": {
+    label: "Workspace Provisioning",
+    title: "Roadmap Ready, Pre-Build",
+    description:
+      "Drop in your final roadmap and let the wizard generate the repo automations, context packs, and status surfaces you will need for build.",
+    cta: {
+      eyebrow: "Provisioning workspace",
+      title: "Import roadmap.yml and scaffold automations",
+      description:
+        "Upload your existing docs/roadmap.yml, validate it, and generate infra facts, tech stack, and roadmap workflow files in one flow.",
+      action: {
+        href: "/wizard/roadmap/workspace",
+        label: "Launch provisioning workspace",
+      },
+      note: "Commits docs/roadmap.yml along with docs/infra-facts.md, docs/tech-stack.yml, and .github/workflows/roadmap.yml if they are missing.",
+    },
+    tools: [
+      {
+        href: "/wizard/roadmap/workspace",
+        label: "Launch provisioning workspace",
+        description:
+          "Upload an existing roadmap.yml, validate it, and scaffold infra-facts, tech stack, and roadmap workflow files.",
+      },
+    ],
+    sections: [
+      {
+        id: "sync",
+        title: "Sync roadmap artifacts",
+        summary:
+          "Upload or paste your roadmap so docs/roadmap.yml, docs/tech-stack.yml, and docs/gtm-plan.md reflect the latest thinking.",
+        checklist: [
+          {
+            title: "Validate milestones",
+            detail: "Confirm epics, owners, and dependencies are tagged so progress tracking stays precise.",
+          },
+          {
+            title: "Align GTM + build",
+            detail: "Map GTM beats to engineering sprints so launches feel coordinated from the start.",
+          },
+          {
+            title: "Generate summary context",
+            detail: "Publish docs/summary.txt so any AI agent can ramp instantly.",
+          },
+        ],
+      },
+      {
+        id: "integrate",
+        title: "Wire automations",
+        summary:
+          "Provision GitHub workflows, Supabase access, and context feeds that keep roadmap status live once development begins.",
+        checklist: [
+          {
+            title: "Connect GitHub",
+            detail: "Authorize the wizard to push scaffolding commits or open pull requests in your repo.",
+          },
+          {
+            title: "Link Supabase",
+            detail: "Share read-only credentials so discovery runs can analyze schema and row-level security.",
+          },
+          {
+            title: "Schedule status reports",
+            detail: "Decide how often docs/roadmap-status.json should refresh and who receives updates.",
+          },
+        ],
+      },
+    ],
+    resources: [
+      { label: "Back to wizard", href: "/wizard" },
+      { label: "Launch provisioning workspace", href: "/wizard/roadmap/workspace" },
+      { label: "Provision automations", href: "/api/setup" },
+    ],
+  },
+  "mid-build": {
+    label: "Discovery Mode",
+    title: "Mid-Project Build",
+    description:
+      "Overlay discovery mode on your live project so AI copilots see what changed, what shipped, and what needs attention next.",
+    cta: {
+      eyebrow: "Current state sync",
+      title: "Refresh roadmap status before diving in",
+      description:
+        "Launch the mid-project sync workspace to run /api/run and /api/discover, then preview the updated status grid and backlog list.",
+      action: {
+        href: "/wizard/midproject/workspace",
+        label: "Launch mid-project sync",
+      },
+      note: "Generates docs/roadmap-status.json, docs/project-plan.md, and docs/backlog-discovered.yml so the dashboard is already current.",
+    },
+    tools: [
+      {
+        href: "/wizard/midproject/workspace",
+        label: "Launch mid-project sync",
+        description:
+          "Run status + discover workflows and preview backlog discoveries before opening the dashboard.",
+      },
+    ],
+    sections: [
+      {
+        id: "ingest",
+        title: "Load current context",
+        summary:
+          "Pull the latest code, Supabase schema, and roadmap status so the wizard reflects reality before any new suggestions drop.",
+        checklist: [
+          {
+            title: "Scan the repo",
+            detail: "Index commits, open PRs, and drift from docs/roadmap.yml to understand real progress.",
+          },
+          {
+            title: "Run discovery checks",
+            detail: "Use the discover API to surface off-roadmap work or regressions that need triage.",
+          },
+          {
+            title: "Regenerate context pack",
+            detail: "Publish a fresh bundle for your AI teammates so they jump in fully briefed.",
+          },
+        ],
+      },
+      {
+        id: "plan",
+        title: "Shape the next sprint",
+        summary:
+          "Blend roadmap goals with discovered insights to keep the build plan accurate and resilient.",
+        checklist: [
+          {
+            title: "Prioritize surfaced work",
+            detail: "Accept or reject the discover list so roadmap status stays trustworthy.",
+          },
+          {
+            title: "Update success metrics",
+            detail: "Refine targets based on what you have learned mid-flight.",
+          },
+          {
+            title: "Loop in your AI partner",
+            detail: "Assign coding tasks or ask for implementation help backed by the refreshed context pack.",
+          },
+        ],
+      },
+    ],
+    resources: [
+      { label: "Back to wizard", href: "/wizard" },
+      { label: "Launch mid-project sync", href: "/wizard/midproject/workspace" },
+      { label: "Run discovery workflow", href: "/wizard/midproject/workspace#discover" },
+    ],
+  },
+} as const satisfies Record<string, StageConfig>;
+
+type StageKey = keyof typeof STAGES;
+
+type WizardStatePageProps = {
+  params: { state: string };
+};
+
+export default function WizardStatePage({ params }: WizardStatePageProps) {
+  const stageKey = params.state as StageKey;
+  const stage = STAGES[stageKey];
+
+  if (!stage) {
+    notFound();
+  }
+
+  return (
+    <section className="tw-space-y-10">
+      <div className="tw-space-y-3">
+        <Link
+          href="/wizard"
+          className="tw-inline-flex tw-items-center tw-gap-2 tw-text-sm tw-text-slate-300 tw-transition tw-duration-200 tw-ease-out hover:tw-text-slate-100"
+        >
+          <span aria-hidden="true">←</span>
+          <span>Back to wizard</span>
+        </Link>
+        <span className="tw-inline-flex tw-items-center tw-gap-2 tw-rounded-full tw-border tw-border-slate-800 tw-px-3 tw-py-1 tw-text-xs tw-font-medium tw-uppercase tw-tracking-wide tw-text-slate-300">
+          {stage.label}
+        </span>
+        <h1 className="tw-text-3xl tw-font-bold tw-leading-tight tw-text-slate-100">{stage.title}</h1>
+        <p className="tw-text-lg tw-leading-relaxed tw-text-slate-300">{stage.description}</p>
+      </div>
+
+      {stage.cta && (
+        <div className="tw-rounded-3xl tw-border tw-border-blue-500/40 tw-bg-blue-500/10 tw-p-6 tw-flex tw-flex-col tw-gap-4">
+          <div className="tw-space-y-2">
+            <span className="tw-inline-flex tw-items-center tw-gap-2 tw-rounded-full tw-border tw-border-blue-500/40 tw-bg-blue-500/10 tw-px-3 tw-py-1 tw-text-xs tw-font-semibold tw-uppercase tw-tracking-wide tw-text-blue-200">
+              {stage.cta.eyebrow}
+            </span>
+            <h2 className="tw-text-2xl tw-font-semibold tw-text-blue-100">{stage.cta.title}</h2>
+            <p className="tw-text-sm tw-leading-relaxed tw-text-blue-100/80">{stage.cta.description}</p>
+          </div>
+          <div className="tw-flex tw-flex-wrap tw-items-center tw-gap-3">
+            <Link
+              href={stage.cta.action.href}
+              className="tw-inline-flex tw-items-center tw-gap-2 tw-rounded-full tw-bg-blue-500 tw-px-4 tw-py-2 tw-text-sm tw-font-semibold tw-text-blue-50 tw-shadow-lg tw-shadow-blue-500/30 tw-transition tw-duration-200 tw-ease-out hover:tw-bg-blue-400"
+            >
+              <span>{stage.cta.action.label}</span>
+              <span aria-hidden="true">→</span>
+            </Link>
+            <p className="tw-text-xs tw-text-blue-100/70">{stage.cta.note}</p>
+          </div>
+        </div>
+      )}
+
+      {stage.tools?.length ? (
+        <div className="tw-space-y-3">
+          <h2 className="tw-text-sm tw-font-semibold tw-uppercase tw-tracking-wide tw-text-slate-300">
+            Access the workspace
+          </h2>
+          <div className="tw-flex tw-flex-wrap tw-items-center tw-gap-3">
+            {stage.tools.map((tool) => (
+              <Link
+                key={tool.href}
+                href={tool.href}
+                className="tw-inline-flex tw-items-center tw-gap-2 tw-rounded-full tw-border tw-border-slate-700 tw-bg-slate-900 tw-px-4 tw-py-2 tw-text-sm tw-font-semibold tw-text-slate-200 tw-transition tw-duration-200 tw-ease-out hover:tw-border-slate-600 hover:tw-text-slate-100"
+              >
+                <span>{tool.label}</span>
+                <span aria-hidden="true">↗</span>
+              </Link>
+            ))}
+          </div>
+          {stage.tools.some((tool) => Boolean(tool.description)) ? (
+            <ul className="tw-space-y-1 tw-text-xs tw-text-slate-400">
+              {stage.tools.map((tool) =>
+                tool.description ? (
+                  <li key={`${tool.href}-description`}>{tool.description}</li>
+                ) : null,
+              )}
+            </ul>
+          ) : null}
+        </div>
+      ) : null}
+
+      <div className="tw-grid tw-gap-6 md:tw-grid-cols-2">
+        {stage.sections.map((section) => (
+          <div
+            key={section.id}
+            className="tw-rounded-3xl tw-border tw-border-slate-800 tw-bg-slate-900 tw-p-6 tw-flex tw-flex-col tw-gap-4"
+          >
+            <div className="tw-space-y-2">
+              <h2 className="tw-text-xl tw-font-semibold tw-leading-snug tw-text-slate-100">{section.title}</h2>
+              <p className="tw-text-sm tw-leading-relaxed tw-text-slate-300">{section.summary}</p>
+            </div>
+            <ul className="tw-space-y-2 tw-text-sm tw-text-slate-300 tw-list-disc tw-pl-5">
+              {section.checklist.map((item) => (
+                <li key={item.title} className="tw-leading-relaxed">
+                  <span className="tw-font-medium tw-text-slate-100 tw-block">{item.title}</span>
+                  <span className="tw-text-slate-300">{item.detail}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ))}
+      </div>
+
+      {stage.resources.length > 0 && (
+        <div className="tw-flex tw-flex-wrap tw-gap-3">
+          {stage.resources.map((resource) => (
+            <Link
+              key={resource.label}
+              href={resource.href}
+              className="tw-inline-flex tw-items-center tw-gap-2 tw-rounded-full tw-border tw-border-slate-800 tw-px-3 tw-py-1 tw-text-sm tw-font-medium tw-text-slate-300 tw-transition tw-duration-200 tw-ease-out hover:tw-border-slate-700 hover:tw-text-slate-100"
+            >
+              <span>{resource.label}</span>
+              <span aria-hidden="true">→</span>
+            </Link>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/app/wizard/brainstorm/page.tsx
+++ b/app/wizard/brainstorm/page.tsx
@@ -1,0 +1,223 @@
+"use client";
+
+import { FormEvent, useEffect, useMemo, useRef, useState } from "react";
+import Link from "next/link";
+
+type ChatMessage = {
+  role: "user" | "assistant";
+  content: string;
+};
+
+type ChatResponse = {
+  conversationId: string;
+  reply: string;
+};
+
+type ErrorState = {
+  title: string;
+  detail?: string;
+};
+
+export default function BrainstormPage() {
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [input, setInput] = useState("");
+  const [conversationId, setConversationId] = useState<string | null>(null);
+  const [isSending, setIsSending] = useState(false);
+  const [error, setError] = useState<ErrorState | null>(null);
+  const [promoteMessage, setPromoteMessage] = useState<string | null>(null);
+  const [isPromoting, setIsPromoting] = useState(false);
+  const bottomRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (bottomRef.current) {
+      bottomRef.current.scrollIntoView({ behavior: "smooth" });
+    }
+  }, [messages]);
+
+  const hasMessages = messages.length > 0;
+
+  const placeholder = useMemo(
+    () =>
+      "Describe the spark you want to explore, customer pain points, or constraints. The ideation partner will help you expand it.",
+    [],
+  );
+
+  async function sendMessage(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setPromoteMessage(null);
+
+    const trimmed = input.trim();
+    if (!trimmed) {
+      return;
+    }
+
+    const pendingHistory = messages;
+    const payload = {
+      conversationId,
+      history: pendingHistory,
+      message: trimmed,
+    };
+
+    setMessages((prev) => [...prev, { role: "user", content: trimmed }]);
+    setInput("");
+    setIsSending(true);
+    setError(null);
+
+    try {
+      const response = await fetch("/api/brainstorm/chat", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(payload),
+      });
+
+      if (!response.ok) {
+        const detail = await response.json().catch(() => ({}));
+        const title = typeof detail.error === "string" ? detail.error : "We could not reach OpenAI.";
+        const info = typeof detail.detail === "string" ? detail.detail : undefined;
+        setError({ title, detail: info });
+        setMessages((prev) => prev.slice(0, -1));
+        return;
+      }
+
+      const data = (await response.json()) as ChatResponse;
+      setConversationId(data.conversationId);
+      setMessages((prev) => [...prev, { role: "assistant", content: data.reply }]);
+    } catch (err) {
+      setError({ title: "Something went wrong sending your idea.", detail: err instanceof Error ? err.message : undefined });
+      setMessages((prev) => prev.slice(0, -1));
+    } finally {
+      setIsSending(false);
+    }
+  }
+
+  async function handlePromote() {
+    if (!hasMessages) {
+      return;
+    }
+
+    setIsPromoting(true);
+    setPromoteMessage(null);
+    setError(null);
+
+    try {
+      const response = await fetch("/api/brainstorm/promote", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ conversationId, messages }),
+      });
+
+      if (!response.ok) {
+        const detail = await response.json().catch(() => ({}));
+        const title = typeof detail.error === "string" ? detail.error : "Failed to promote idea to project.";
+        const info = typeof detail.detail === "string" ? detail.detail : undefined;
+        setError({ title, detail: info });
+        return;
+      }
+
+      setPromoteMessage("Idea log exported to docs/idea-log.md. You can now turn this into a roadmap.");
+    } catch (err) {
+      setError({ title: "Promotion failed", detail: err instanceof Error ? err.message : undefined });
+    } finally {
+      setIsPromoting(false);
+    }
+  }
+
+  return (
+    <section className="tw-space-y-8">
+      <div className="tw-space-y-3">
+        <Link
+          href="/wizard/new-idea"
+          className="tw-inline-flex tw-items-center tw-gap-2 tw-text-sm tw-text-slate-300 tw-transition tw-duration-200 tw-ease-out hover:tw-text-slate-100"
+        >
+          <span aria-hidden="true">←</span>
+          <span>Back to ideation playbook</span>
+        </Link>
+        <h1 className="tw-text-3xl tw-font-bold tw-leading-tight tw-text-slate-100">Idea Workspace</h1>
+        <p className="tw-text-lg tw-leading-relaxed tw-text-slate-300">
+          Capture every spark in a persistent chat, let AI riff with you, and convert the best ideas into roadmap-ready context.
+        </p>
+        <div className="tw-flex tw-flex-wrap tw-gap-3">
+          <button
+            type="button"
+            className="tw-inline-flex tw-items-center tw-gap-2 tw-rounded-full tw-border tw-border-slate-800 tw-bg-slate-900 tw-px-4 tw-py-2 tw-text-sm tw-font-medium tw-text-slate-100 tw-transition tw-duration-200 tw-ease-out hover:tw-border-slate-700 disabled:tw-opacity-60"
+            onClick={handlePromote}
+            disabled={!hasMessages || isPromoting}
+          >
+            {isPromoting ? "Exporting…" : "Promote to Project"}
+          </button>
+          <span className="tw-text-sm tw-text-slate-400">
+            Each turn is saved to <code className="tw-text-xs">/tmp/ideas</code> so you can reuse the transcript later.
+          </span>
+      </div>
+      </div>
+
+      {error && (
+        <div className="tw-rounded-2xl tw-border tw-border-red-500/40 tw-bg-red-500/10 tw-p-4 tw-text-sm tw-text-red-200">
+          <p className="tw-font-semibold">{error.title}</p>
+          {error.detail && <p className="tw-mt-1 tw-text-red-200">{error.detail}</p>}
+        </div>
+      )}
+
+      {promoteMessage && (
+        <div className="tw-rounded-2xl tw-border tw-border-emerald-500/40 tw-bg-emerald-500/10 tw-p-4 tw-text-sm tw-text-emerald-200">
+          {promoteMessage}
+        </div>
+      )}
+
+      <div className="tw-flex tw-flex-col tw-gap-4 tw-rounded-3xl tw-border tw-border-slate-800 tw-bg-slate-900 tw-p-6 tw-max-h-[60vh] tw-overflow-y-auto">
+        {hasMessages ? (
+          messages.map((message, index) => (
+            <div
+              key={`${message.role}-${index}`}
+              className={
+                message.role === "user"
+                  ? "tw-ml-auto tw-max-w-[75%] tw-rounded-2xl tw-bg-slate-800 tw-px-4 tw-py-3 tw-text-sm tw-text-slate-100"
+                  : "tw-mr-auto tw-max-w-[75%] tw-rounded-2xl tw-bg-slate-950 tw-px-4 tw-py-3 tw-text-sm tw-text-slate-200"
+              }
+            >
+              <p className="tw-text-xs tw-font-semibold tw-uppercase tw-tracking-wide tw-text-slate-400">
+                {message.role === "user" ? "You" : "AI Partner"}
+              </p>
+              <p className="tw-mt-1 tw-whitespace-pre-line">{message.content}</p>
+            </div>
+          ))
+        ) : (
+          <div className="tw-text-sm tw-text-slate-400">
+            Start a conversation with your idea. The assistant will help you shape, expand, and stress-test it.
+          </div>
+        )}
+        <div ref={bottomRef} />
+      </div>
+
+      <form onSubmit={sendMessage} className="tw-space-y-3">
+        <label htmlFor="brainstorm-input" className="tw-text-sm tw-font-medium tw-text-slate-200">
+          Drop your next thought
+        </label>
+        <textarea
+          id="brainstorm-input"
+          className="tw-min-h-[140px] tw-rounded-3xl tw-border tw-border-slate-800 tw-bg-slate-950 tw-p-4 tw-text-sm tw-text-slate-100 focus:tw-border-slate-700"
+          placeholder={placeholder}
+          value={input}
+          onChange={(event) => setInput(event.target.value)}
+          disabled={isSending}
+        />
+        <div className="tw-flex tw-items-center tw-justify-between">
+          <p className="tw-text-xs tw-text-slate-400">
+            OpenAI key required: set <code className="tw-text-[0.75rem]">OPENAI_API_KEY</code> in your environment.
+          </p>
+          <button
+            type="submit"
+            className="tw-inline-flex tw-items-center tw-gap-2 tw-rounded-full tw-border tw-border-slate-800 tw-bg-blue-600/10 tw-px-4 tw-py-2 tw-text-sm tw-font-semibold tw-text-blue-200 tw-transition tw-duration-200 tw-ease-out hover:tw-border-blue-500/60 disabled:tw-opacity-60"
+            disabled={isSending || !input.trim()}
+          >
+            {isSending ? "Thinking…" : "Send idea"}
+          </button>
+        </div>
+      </form>
+    </section>
+  );
+}

--- a/app/wizard/concept/workspace/page.tsx
+++ b/app/wizard/concept/workspace/page.tsx
@@ -1,0 +1,422 @@
+"use client";
+
+import {
+  ChangeEvent,
+  FormEvent,
+  Suspense,
+  UIEvent,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import Link from "next/link";
+import { useSearchParams } from "next/navigation";
+
+type ErrorState = { title: string; detail?: string } | null;
+type SuccessState = string | null;
+
+type GenerateResponse = { roadmap: string };
+
+type CommitResponse = { ok: boolean };
+
+type UploadState = {
+  name: string;
+  sizeLabel: string;
+};
+
+function escapeHtml(value: string) {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function highlightYaml(value: string) {
+  return value
+    .split("\n")
+    .map((line) => {
+      if (!line) {
+        return "";
+      }
+
+      const hashIndex = line.indexOf("#");
+      let main = line;
+      let comment = "";
+      if (hashIndex !== -1) {
+        main = line.slice(0, hashIndex);
+        comment = line.slice(hashIndex);
+      }
+
+      const indentMatch = main.match(/^(\s*)/);
+      const indent = indentMatch ? indentMatch[0] : "";
+      let rest = main.slice(indent.length);
+      let html = escapeHtml(indent);
+
+      if (rest.startsWith("- ")) {
+        html += '<span class="token-dash">- </span>';
+        rest = rest.slice(2);
+      }
+
+      const keyMatch = rest.match(/^([^:]+):(.*)$/);
+      if (keyMatch) {
+        const [, key, rawValue] = keyMatch;
+        const trimmedKey = key.trimEnd();
+        const spacing = key.slice(trimmedKey.length);
+        const valuePart = rawValue ?? "";
+        html += `<span class="token-key">${escapeHtml(trimmedKey)}</span>`;
+        if (spacing) {
+          html += escapeHtml(spacing);
+        }
+        html += '<span class="token-colon">:</span>';
+        if (valuePart.trim()) {
+          html += `<span class="token-string">${escapeHtml(valuePart)}</span>`;
+        } else if (valuePart) {
+          html += escapeHtml(valuePart);
+        }
+      } else {
+        html += escapeHtml(rest);
+      }
+
+      if (comment) {
+        html += `<span class="token-comment">${escapeHtml(comment)}</span>`;
+      }
+
+      return html;
+    })
+    .join("\n");
+}
+
+function formatBytes(bytes: number) {
+  if (Number.isNaN(bytes) || bytes <= 0) {
+    return "0 B";
+  }
+  const units = ["B", "KB", "MB", "GB"];
+  let value = bytes;
+  let unitIndex = 0;
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024;
+    unitIndex += 1;
+  }
+  return `${value.toFixed(value < 10 && unitIndex > 0 ? 1 : 0)} ${units[unitIndex]}`;
+}
+
+function ConceptWizardPageInner() {
+  const params = useSearchParams();
+  const [owner, setOwner] = useState(() => params.get("owner") ?? "");
+  const [repo, setRepo] = useState(() => params.get("repo") ?? "");
+  const [branch, setBranch] = useState(() => params.get("branch") ?? "main");
+  const [conceptText, setConceptText] = useState("");
+  const [upload, setUpload] = useState<UploadState | null>(null);
+  const [uploadText, setUploadText] = useState("");
+  const [filePickerKey, setFilePickerKey] = useState(0);
+  const [isGenerating, setIsGenerating] = useState(false);
+  const [roadmap, setRoadmap] = useState("");
+  const [error, setError] = useState<ErrorState>(null);
+  const [success, setSuccess] = useState<SuccessState>(null);
+  const [isCommitting, setIsCommitting] = useState(false);
+  const previewRef = useRef<HTMLPreElement | null>(null);
+  const editorRef = useRef<HTMLTextAreaElement | null>(null);
+
+  const combinedPrompt = useMemo(() => {
+    if (conceptText && uploadText) {
+      return `${conceptText.trim()}\n\nUploaded context:\n${uploadText.trim()}`;
+    }
+    if (conceptText) return conceptText.trim();
+    if (uploadText) return uploadText.trim();
+    return "";
+  }, [conceptText, uploadText]);
+
+  const highlighted = useMemo(() => highlightYaml(roadmap || ""), [roadmap]);
+
+  useEffect(() => {
+    if (previewRef.current && editorRef.current) {
+      previewRef.current.scrollTop = editorRef.current.scrollTop;
+      previewRef.current.scrollLeft = editorRef.current.scrollLeft;
+    }
+  }, [roadmap]);
+
+  const canGenerate = Boolean(!isGenerating && combinedPrompt);
+  const canCommit = Boolean(!isCommitting && roadmap.trim() && owner && repo);
+
+  async function onGenerate(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!combinedPrompt) {
+      setError({ title: "Provide concept details", detail: "Paste text or upload a document before generating." });
+      return;
+    }
+
+    setIsGenerating(true);
+    setError(null);
+    setSuccess(null);
+
+    try {
+      const response = await fetch("/api/concept/generate", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ prompt: combinedPrompt }),
+      });
+
+      if (!response.ok) {
+        const detail = await response.json().catch(() => ({}));
+        const title = typeof detail.error === "string" ? detail.error : "Failed to generate roadmap";
+        const info = typeof detail.detail === "string" ? detail.detail : undefined;
+        setError({ title, detail: info });
+        return;
+      }
+
+      const data = (await response.json()) as GenerateResponse;
+      setRoadmap(data.roadmap.trim());
+      setSuccess("Draft roadmap ready. Review and edit before committing to your repo.");
+    } catch (err) {
+      setError({ title: "Generation failed", detail: err instanceof Error ? err.message : String(err) });
+    } finally {
+      setIsGenerating(false);
+    }
+  }
+
+  function syncScroll(event: UIEvent<HTMLTextAreaElement>) {
+    const target = event.currentTarget;
+    if (previewRef.current) {
+      previewRef.current.scrollTop = target.scrollTop;
+      previewRef.current.scrollLeft = target.scrollLeft;
+    }
+  }
+
+  function onFileChange(event: ChangeEvent<HTMLInputElement>) {
+    const file = event.target.files?.[0];
+    if (!file) {
+      setUpload(null);
+      setUploadText("");
+      setFilePickerKey((value) => value + 1);
+      return;
+    }
+    if (file.size > 2 * 1024 * 1024) {
+      setError({ title: "File too large", detail: "Limit uploads to 2MB text documents." });
+      event.target.value = "";
+      setFilePickerKey((value) => value + 1);
+      return;
+    }
+
+    const reader = new FileReader();
+    reader.onload = () => {
+      const text = typeof reader.result === "string" ? reader.result : "";
+      setUpload({ name: file.name, sizeLabel: formatBytes(file.size) });
+      setUploadText(text.trim());
+    };
+    reader.onerror = () => {
+      setError({ title: "Failed to read file", detail: "Try uploading a plain text or markdown document." });
+      setUpload(null);
+      setUploadText("");
+      setFilePickerKey((value) => value + 1);
+    };
+    reader.readAsText(file);
+  }
+
+  function resetUpload() {
+    setUpload(null);
+    setUploadText("");
+    setFilePickerKey((value) => value + 1);
+  }
+
+  async function onCommit() {
+    if (!roadmap.trim()) {
+      setError({ title: "Roadmap is empty", detail: "Generate or paste roadmap content before committing." });
+      return;
+    }
+    if (!owner || !repo) {
+      setError({ title: "Connect a repo", detail: "Provide owner and repo so the wizard can push docs/roadmap.yml." });
+      return;
+    }
+
+    setIsCommitting(true);
+    setError(null);
+    setSuccess(null);
+
+    try {
+      const response = await fetch("/api/concept/commit", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ owner, repo, branch: branch || "main", content: roadmap }),
+      });
+
+      if (!response.ok) {
+        const detail = await response.json().catch(() => ({}));
+        const title = typeof detail.error === "string" ? detail.error : "Commit failed";
+        const info = typeof detail.detail === "string" ? detail.detail : undefined;
+        setError({ title, detail: info });
+        return;
+      }
+
+      const data = (await response.json()) as CommitResponse;
+      if (data.ok) {
+        setSuccess("docs/roadmap.yml created in your repo. Open a PR or keep iterating on the plan.");
+      } else {
+        setError({ title: "Unexpected response", detail: "The commit endpoint did not confirm success." });
+      }
+    } catch (err) {
+      setError({ title: "Commit failed", detail: err instanceof Error ? err.message : String(err) });
+    } finally {
+      setIsCommitting(false);
+    }
+  }
+
+  return (
+    <section className="tw-space-y-8">
+      <div className="tw-space-y-3">
+        <Link
+          href="/wizard/concept"
+          prefetch={false}
+          className="tw-inline-flex tw-items-center tw-gap-2 tw-text-sm tw-text-slate-300 tw-transition tw-duration-200 tw-ease-out hover:tw-text-slate-100"
+        >
+          <span aria-hidden="true">←</span>
+          <span>Back to roadmap playbook</span>
+        </Link>
+        <h1 className="tw-text-3xl tw-font-bold tw-leading-tight tw-text-slate-100">Concept to Roadmap</h1>
+        <p className="tw-text-lg tw-leading-relaxed tw-text-slate-300">
+          Paste your concept brief or upload research notes, generate a structured roadmap, and push docs/roadmap.yml to your repo.
+        </p>
+      </div>
+
+      <form onSubmit={onGenerate} className="tw-grid tw-gap-6 tw-rounded-3xl tw-border tw-border-slate-800 tw-bg-slate-900 tw-p-6">
+        <div className="tw-space-y-2">
+          <label className="tw-text-sm tw-font-medium tw-text-slate-200">Concept notes</label>
+          <textarea
+            value={conceptText}
+            onChange={(event) => setConceptText(event.target.value)}
+            className="tw-min-h-[160px] tw-w-full tw-resize-y tw-rounded-2xl tw-border tw-border-slate-800 tw-bg-slate-950/80 tw-p-4 tw-text-sm tw-text-slate-100 tw-outline-none focus:tw-border-slate-600"
+            placeholder="Paste the problem statement, audience, constraints, or existing brainstorming transcript."
+          />
+        </div>
+
+        <div className="tw-space-y-2">
+          <label className="tw-text-sm tw-font-medium tw-text-slate-200">Or upload supporting brief</label>
+          <div className="tw-flex tw-flex-wrap tw-items-center tw-justify-between tw-gap-3 tw-rounded-2xl tw-border tw-border-dashed tw-border-slate-700 tw-bg-slate-950/60 tw-p-4">
+            <div className="tw-space-y-1">
+              <p className="tw-text-sm tw-font-medium tw-text-slate-100">Attach markdown, text, or YAML exports</p>
+              <p className="tw-text-xs tw-text-slate-400">.md, .txt, .json, .yaml up to 2MB</p>
+              {upload && (
+                <div className="tw-text-xs tw-text-slate-300">
+                  {upload.name} <span className="tw-text-slate-500">({upload.sizeLabel})</span>
+                </div>
+              )}
+            </div>
+            <div className="tw-flex tw-items-center tw-gap-2">
+              {upload && (
+                <button
+                  type="button"
+                  onClick={resetUpload}
+                  className="tw-inline-flex tw-items-center tw-gap-1 tw-rounded-full tw-border tw-border-slate-700 tw-bg-slate-900 tw-px-3 tw-py-1 tw-text-xs tw-font-medium tw-text-slate-300 hover:tw-border-slate-600"
+                >
+                  Clear
+                </button>
+              )}
+              <label className="tw-inline-flex tw-cursor-pointer tw-items-center tw-gap-2 tw-rounded-full tw-border tw-border-slate-700 tw-bg-slate-900 tw-px-4 tw-py-2 tw-text-xs tw-font-semibold tw-uppercase tw-tracking-wide tw-text-slate-100 hover:tw-border-slate-500">
+                Upload
+                <input
+                  key={filePickerKey}
+                  type="file"
+                  accept=".md,.txt,.markdown,.yaml,.yml,.json"
+                  onChange={onFileChange}
+                  className="tw-hidden"
+                />
+              </label>
+            </div>
+          </div>
+        </div>
+
+        <div className="tw-flex tw-flex-wrap tw-items-center tw-justify-between tw-gap-3">
+          <div className="tw-text-xs tw-text-slate-400">
+            Provide either pasted context or an upload. The wizard blends both sources when available.
+          </div>
+          <button
+            type="submit"
+            disabled={!canGenerate}
+            className="tw-inline-flex tw-items-center tw-gap-2 tw-rounded-full tw-border tw-border-slate-800 tw-bg-slate-100 tw-px-4 tw-py-2 tw-text-sm tw-font-semibold tw-text-slate-900 tw-transition tw-duration-200 tw-ease-out disabled:tw-cursor-not-allowed disabled:tw-border-slate-800/60 disabled:tw-bg-slate-700/40 disabled:tw-text-slate-400 hover:tw-bg-white"
+          >
+            {isGenerating ? "Generating…" : "Generate Roadmap"}
+          </button>
+        </div>
+      </form>
+
+      {(error || success) && (
+        <div className="tw-space-y-3">
+          {error && (
+            <div className="tw-rounded-2xl tw-border tw-border-red-500/40 tw-bg-red-500/10 tw-p-4 tw-text-sm tw-text-red-200">
+              <p className="tw-font-semibold">{error.title}</p>
+              {error.detail && <p className="tw-mt-1 tw-text-xs tw-text-red-200/80">{error.detail}</p>}
+            </div>
+          )}
+          {success && !error && (
+            <div className="tw-rounded-2xl tw-border tw-border-emerald-500/40 tw-bg-emerald-500/10 tw-p-4 tw-text-sm tw-text-emerald-200">
+              {success}
+            </div>
+          )}
+        </div>
+      )}
+
+      <div className="tw-grid tw-gap-4">
+        <div className="tw-flex tw-flex-wrap tw-items-center tw-justify-between tw-gap-3">
+          <h2 className="tw-text-xl tw-font-semibold tw-text-slate-100">docs/roadmap.yml</h2>
+          <div className="tw-flex tw-flex-wrap tw-items-center tw-gap-2">
+            <input
+              value={owner}
+              onChange={(event) => setOwner(event.target.value)}
+              placeholder="owner"
+              className="tw-w-32 tw-rounded-full tw-border tw-border-slate-800 tw-bg-slate-950/70 tw-px-3 tw-py-1.5 tw-text-xs tw-text-slate-100 focus:tw-border-slate-600"
+            />
+            <span className="tw-text-slate-400">/</span>
+            <input
+              value={repo}
+              onChange={(event) => setRepo(event.target.value)}
+              placeholder="repo"
+              className="tw-w-40 tw-rounded-full tw-border tw-border-slate-800 tw-bg-slate-950/70 tw-px-3 tw-py-1.5 tw-text-xs tw-text-slate-100 focus:tw-border-slate-600"
+            />
+            <input
+              value={branch}
+              onChange={(event) => setBranch(event.target.value)}
+              placeholder="branch"
+              className="tw-w-32 tw-rounded-full tw-border tw-border-slate-800 tw-bg-slate-950/70 tw-px-3 tw-py-1.5 tw-text-xs tw-text-slate-100 focus:tw-border-slate-600"
+            />
+            <button
+              type="button"
+              onClick={onCommit}
+              disabled={!canCommit}
+              className="tw-inline-flex tw-items-center tw-gap-2 tw-rounded-full tw-border tw-border-slate-800 tw-bg-emerald-400/90 tw-px-4 tw-py-2 tw-text-sm tw-font-semibold tw-text-slate-900 tw-transition tw-duration-200 tw-ease-out disabled:tw-cursor-not-allowed disabled:tw-border-slate-800/60 disabled:tw-bg-slate-700/40 disabled:tw-text-slate-400 hover:tw-bg-emerald-300"
+            >
+              {isCommitting ? "Committing…" : "Commit to Repo"}
+            </button>
+          </div>
+        </div>
+
+        <div className="code-editor">
+          <pre
+            ref={previewRef}
+            className="code-editor__preview"
+            aria-hidden="true"
+            dangerouslySetInnerHTML={{ __html: highlighted || "" }}
+          />
+          <textarea
+            ref={editorRef}
+            value={roadmap}
+            onChange={(event) => setRoadmap(event.target.value)}
+            spellCheck={false}
+            placeholder="# Generated roadmap YAML will appear here"
+            className="code-editor__textarea"
+            onScroll={syncScroll}
+          />
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export default function ConceptWizardPage() {
+  return (
+    <Suspense fallback={<div className="tw-px-6 tw-py-10 tw-text-sm tw-text-slate-400">Loading concept workspace…</div>}>
+      <ConceptWizardPageInner />
+    </Suspense>
+  );
+}

--- a/app/wizard/midproject/page.tsx
+++ b/app/wizard/midproject/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function MidProjectWorkspaceRedirect() {
+  redirect("/wizard/midproject/workspace");
+}

--- a/app/wizard/midproject/workspace/page.tsx
+++ b/app/wizard/midproject/workspace/page.tsx
@@ -1,0 +1,341 @@
+"use client";
+
+import { FormEvent, useMemo, useState } from "react";
+import Link from "next/link";
+
+import StatusGrid from "@/components/StatusGrid";
+
+type ErrorState = { title: string; detail?: string } | null;
+
+type RunResponse = {
+  ok?: boolean;
+  wrote?: string[];
+  error?: string;
+  detail?: string;
+};
+
+type BacklogItem = {
+  id: string;
+  title: string;
+  status: string;
+};
+
+type DiscoverResponse = {
+  ok?: boolean;
+  discovered?: number;
+  items?: BacklogItem[];
+  wrote?: string[];
+  error?: string;
+  detail?: string;
+};
+
+type RoadmapStatus = {
+  generated_at?: string;
+  weeks?: any[];
+};
+
+export default function MidProjectSyncWorkspace() {
+  const [owner, setOwner] = useState("");
+  const [repo, setRepo] = useState("");
+  const [branch, setBranch] = useState("main");
+  const [probeUrl, setProbeUrl] = useState("");
+
+  const [status, setStatus] = useState<RoadmapStatus | null>(null);
+  const [backlog, setBacklog] = useState<BacklogItem[]>([]);
+  const [runArtifacts, setRunArtifacts] = useState<string[]>([]);
+  const [discoverArtifacts, setDiscoverArtifacts] = useState<string[]>([]);
+  const [lastSyncedAt, setLastSyncedAt] = useState<string | null>(null);
+
+  const [error, setError] = useState<ErrorState>(null);
+  const [isSyncing, setIsSyncing] = useState(false);
+
+  const repoSlug = useMemo(() => {
+    const o = owner.trim();
+    const r = repo.trim();
+    return o && r ? `${o}/${r}` : null;
+  }, [owner, repo]);
+
+  const canSubmit = Boolean(!isSyncing && repoSlug);
+
+  async function handleSync(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!repoSlug) {
+      setError({ title: "Provide owner and repository", detail: "Fill both fields before connecting." });
+      return;
+    }
+
+    setIsSyncing(true);
+    setError(null);
+    setStatus(null);
+    setBacklog([]);
+    setRunArtifacts([]);
+    setDiscoverArtifacts([]);
+
+    const payload = {
+      owner: owner.trim(),
+      repo: repo.trim(),
+      branch: branch.trim() || "main",
+      ...(probeUrl.trim() ? { probeUrl: probeUrl.trim() } : {}),
+    };
+
+    try {
+      const runResponse = await fetch("/api/run", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      const runJson = (await runResponse.json()) as RunResponse;
+      if (!runResponse.ok || runJson?.ok === false || runJson?.error) {
+        throw new Error(runJson?.error || "Failed to refresh roadmap status");
+      }
+      setRunArtifacts(runJson?.wrote ?? []);
+
+      const statusResponse = await fetch(
+        `/api/status/${payload.owner}/${payload.repo}?branch=${encodeURIComponent(payload.branch)}`,
+        { cache: "no-store" },
+      );
+      if (statusResponse.ok) {
+        const statusJson = (await statusResponse.json()) as RoadmapStatus;
+        setStatus(statusJson);
+      } else {
+        setStatus(null);
+      }
+
+      const discoverResponse = await fetch("/api/discover", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      const discoverJson = (await discoverResponse.json()) as DiscoverResponse;
+      if (!discoverResponse.ok || discoverJson?.ok === false || discoverJson?.error) {
+        throw new Error(discoverJson?.error || "Discover run failed");
+      }
+      setDiscoverArtifacts(discoverJson?.wrote ?? []);
+      setBacklog(discoverJson?.items ?? []);
+
+      setLastSyncedAt(new Date().toISOString());
+    } catch (err: any) {
+      setError({
+        title: "Sync failed",
+        detail: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      setIsSyncing(false);
+    }
+  }
+
+  const statusGeneratedAt = status?.generated_at
+    ? new Date(status.generated_at).toLocaleString()
+    : lastSyncedAt
+    ? new Date(lastSyncedAt).toLocaleString()
+    : null;
+
+  return (
+    <div className="tw-space-y-10">
+      <div>
+        <Link
+          href="/wizard/mid-build"
+          className="tw-inline-flex tw-items-center tw-gap-2 tw-rounded-full tw-border tw-border-slate-800 tw-bg-slate-950 tw-px-3 tw-py-1 tw-text-xs tw-font-medium tw-uppercase tw-tracking-wide tw-text-slate-300 hover:tw-border-slate-700 hover:tw-text-slate-100"
+        >
+          <span aria-hidden="true">←</span>
+          <span>Back to mid-project playbook</span>
+        </Link>
+      </div>
+
+      <header className="tw-space-y-3">
+        <span className="tw-inline-flex tw-items-center tw-gap-2 tw-rounded-full tw-border tw-border-slate-800 tw-px-3 tw-py-1 tw-text-xs tw-font-medium tw-uppercase tw-tracking-wide tw-text-slate-300">
+          Mid-project sync
+        </span>
+        <h1 className="tw-text-3xl tw-font-bold tw-leading-tight tw-text-slate-100">Refresh live project context</h1>
+        <p className="tw-text-base tw-leading-relaxed tw-text-slate-300">
+          Connect an active repository to regenerate roadmap status and discovery insights before diving into the full dashboard.
+        </p>
+      </header>
+
+      <form onSubmit={handleSync} className="tw-grid tw-gap-8 lg:tw-grid-cols-[1.4fr,1fr]">
+        <section className="tw-space-y-6 tw-rounded-3xl tw-border tw-border-slate-800 tw-bg-slate-900 tw-p-8">
+          <div className="tw-grid tw-gap-4 md:tw-grid-cols-2">
+            <label className="tw-flex tw-flex-col tw-gap-2">
+              <span className="tw-text-sm tw-font-medium tw-text-slate-200">Owner</span>
+              <input
+                value={owner}
+                onChange={(event) => setOwner(event.target.value)}
+                placeholder="acme-co"
+                className="tw-w-full tw-rounded-xl tw-border tw-border-slate-700 tw-bg-slate-950 tw-px-3 tw-py-2 tw-text-sm tw-text-slate-100 tw-placeholder-slate-500 focus:tw-border-slate-500 focus:tw-outline-none"
+              />
+            </label>
+            <label className="tw-flex tw-flex-col tw-gap-2">
+              <span className="tw-text-sm tw-font-medium tw-text-slate-200">Repository</span>
+              <input
+                value={repo}
+                onChange={(event) => setRepo(event.target.value)}
+                placeholder="product-app"
+                className="tw-w-full tw-rounded-xl tw-border tw-border-slate-700 tw-bg-slate-950 tw-px-3 tw-py-2 tw-text-sm tw-text-slate-100 tw-placeholder-slate-500 focus:tw-border-slate-500 focus:tw-outline-none"
+              />
+            </label>
+            <label className="tw-flex tw-flex-col tw-gap-2">
+              <span className="tw-text-sm tw-font-medium tw-text-slate-200">Branch</span>
+              <input
+                value={branch}
+                onChange={(event) => setBranch(event.target.value)}
+                placeholder="main"
+                className="tw-w-full tw-rounded-xl tw-border tw-border-slate-700 tw-bg-slate-950 tw-px-3 tw-py-2 tw-text-sm tw-text-slate-100 tw-placeholder-slate-500 focus:tw-border-slate-500 focus:tw-outline-none"
+              />
+            </label>
+            <label className="tw-flex tw-flex-col tw-gap-2">
+              <span className="tw-text-sm tw-font-medium tw-text-slate-200">Supabase probe URL (optional)</span>
+              <input
+                value={probeUrl}
+                onChange={(event) => setProbeUrl(event.target.value)}
+                placeholder="https://.../rest/v1/rpc/roadmap_probe"
+                className="tw-w-full tw-rounded-xl tw-border tw-border-slate-700 tw-bg-slate-950 tw-px-3 tw-py-2 tw-text-sm tw-text-slate-100 tw-placeholder-slate-500 focus:tw-border-slate-500 focus:tw-outline-none"
+              />
+            </label>
+          </div>
+
+          <div className="tw-flex tw-flex-wrap tw-items-center tw-justify-between tw-gap-4">
+            <div className="tw-text-sm tw-text-slate-400">
+              {statusGeneratedAt ? (
+                <span>Last synced {statusGeneratedAt}</span>
+              ) : (
+                <span>Run discovery to generate the latest status and backlog files.</span>
+              )}
+            </div>
+            <button
+              type="submit"
+              className="tw-inline-flex tw-items-center tw-gap-2 tw-rounded-full tw-bg-slate-100 tw-px-5 tw-py-2 tw-text-sm tw-font-semibold tw-text-slate-900 tw-transition tw-duration-200 tw-ease-out hover:tw-bg-slate-200 disabled:tw-cursor-not-allowed disabled:tw-bg-slate-700 disabled:tw-text-slate-400"
+              disabled={!canSubmit}
+            >
+              {isSyncing ? "Syncing…" : "Connect and sync"}
+            </button>
+          </div>
+
+          {error ? (
+            <div className="tw-rounded-2xl tw-border tw-border-red-500/40 tw-bg-red-500/10 tw-p-4 tw-text-sm tw-text-red-100">
+              <div className="tw-font-semibold">{error.title}</div>
+              {error.detail ? <div className="tw-text-red-100/80">{error.detail}</div> : null}
+            </div>
+          ) : null}
+        </section>
+
+        <aside className="tw-space-y-4 tw-rounded-3xl tw-border tw-border-slate-800 tw-bg-slate-900 tw-p-8">
+          <h2 className="tw-text-xl tw-font-semibold tw-text-slate-100">What this sync runs</h2>
+          <ul className="tw-space-y-3 tw-text-sm tw-text-slate-300 tw-list-disc tw-pl-5">
+            <li>
+              <span className="tw-font-medium tw-text-slate-100">/api/run</span> regenerates docs/roadmap-status.json and project-plan context.
+            </li>
+            <li>
+              <span className="tw-font-medium tw-text-slate-100">/api/discover</span> looks for completed work outside the roadmap and updates docs/backlog-discovered.yml.
+            </li>
+            <li>Bring a Supabase probe URL to surface database checks along with code signals.</li>
+          </ul>
+          {repoSlug ? (
+            <Link
+              href={`/${repoSlug}`}
+              className="tw-inline-flex tw-items-center tw-gap-2 tw-rounded-full tw-border tw-border-slate-700 tw-bg-slate-900 tw-px-4 tw-py-2 tw-text-sm tw-font-semibold tw-text-slate-200 tw-transition tw-duration-200 tw-ease-out hover:tw-border-slate-600 hover:tw-text-slate-100"
+            >
+              <span>Open {repoSlug} dashboard</span>
+              <span aria-hidden="true">↗</span>
+            </Link>
+          ) : null}
+        </aside>
+      </form>
+
+      <section className="tw-grid tw-gap-6 xl:tw-grid-cols-2">
+        <div
+          id="discover"
+          className="tw-space-y-4 tw-rounded-3xl tw-border tw-border-slate-800 tw-bg-slate-900 tw-p-8"
+        >
+          <div className="tw-flex tw-items-center tw-justify-between tw-gap-3">
+            <div>
+              <h2 className="tw-text-xl tw-font-semibold tw-text-slate-100">Roadmap status</h2>
+              <p className="tw-text-sm tw-text-slate-300">Snapshot of docs/roadmap-status.json after the latest run.</p>
+            </div>
+            {statusGeneratedAt ? (
+              <span className="tw-rounded-full tw-border tw-border-slate-800 tw-bg-slate-950 tw-px-3 tw-py-1 tw-text-xs tw-font-medium tw-text-slate-400">
+                {statusGeneratedAt}
+              </span>
+            ) : null}
+          </div>
+          {status?.weeks?.length ? (
+            <StatusGrid status={status} />
+          ) : (
+            <div className="tw-rounded-2xl tw-border tw-border-slate-800 tw-bg-slate-950 tw-px-4 tw-py-8 tw-text-center tw-text-sm tw-text-slate-400">
+              Run the sync to populate the roadmap status grid.
+            </div>
+          )}
+        </div>
+
+        <div className="tw-space-y-4 tw-rounded-3xl tw-border tw-border-slate-800 tw-bg-slate-900 tw-p-8">
+          <div className="tw-flex tw-items-center tw-justify-between tw-gap-3">
+            <div>
+              <h2 className="tw-text-xl tw-font-semibold tw-text-slate-100">Backlog discoveries</h2>
+              <p className="tw-text-sm tw-text-slate-300">Preview of docs/backlog-discovered.yml entries to triage.</p>
+            </div>
+            {discoverArtifacts.length ? (
+              <span className="tw-rounded-full tw-border tw-border-slate-800 tw-bg-slate-950 tw-px-3 tw-py-1 tw-text-xs tw-font-medium tw-text-slate-400">
+                {discoverArtifacts.length} files touched
+              </span>
+            ) : null}
+          </div>
+          {backlog.length ? (
+            <ul className="tw-space-y-3">
+              {backlog.map((item) => (
+                <li
+                  key={item.id}
+                  className="tw-flex tw-items-start tw-gap-3 tw-rounded-2xl tw-border tw-border-slate-800 tw-bg-slate-950 tw-p-4"
+                >
+                  <span className="tw-text-lg" aria-hidden="true">
+                    {item.status === "complete" ? "✅" : "•"}
+                  </span>
+                  <div className="tw-space-y-1">
+                    <p className="tw-text-sm tw-font-semibold tw-text-slate-100">{item.title}</p>
+                    <p className="tw-text-xs tw-uppercase tw-tracking-wide tw-text-slate-400">{item.id}</p>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <div className="tw-rounded-2xl tw-border tw-border-slate-800 tw-bg-slate-950 tw-px-4 tw-py-8 tw-text-center tw-text-sm tw-text-slate-400">
+              Discover runs will surface completed work that never landed on the roadmap.
+            </div>
+          )}
+        </div>
+
+        <div className="tw-space-y-4 tw-rounded-3xl tw-border tw-border-slate-800 tw-bg-slate-900 tw-p-8 xl:tw-col-span-2">
+          <h2 className="tw-text-xl tw-font-semibold tw-text-slate-100">Artifacts updated</h2>
+          <div className="tw-grid tw-gap-4 md:tw-grid-cols-2">
+            <div className="tw-space-y-2">
+              <h3 className="tw-text-sm tw-font-semibold tw-text-slate-200">Status run</h3>
+              {runArtifacts.length ? (
+                <ul className="tw-space-y-1 tw-text-sm tw-text-slate-300">
+                  {runArtifacts.map((path) => (
+                    <li key={path} className="tw-rounded-xl tw-border tw-border-slate-800 tw-bg-slate-950 tw-px-3 tw-py-2">
+                      {path}
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <p className="tw-text-sm tw-text-slate-400">Run the sync to regenerate roadmap artifacts.</p>
+              )}
+            </div>
+            <div className="tw-space-y-2">
+              <h3 className="tw-text-sm tw-font-semibold tw-text-slate-200">Discover run</h3>
+              {discoverArtifacts.length ? (
+                <ul className="tw-space-y-1 tw-text-sm tw-text-slate-300">
+                  {discoverArtifacts.map((path) => (
+                    <li key={path} className="tw-rounded-xl tw-border tw-border-slate-800 tw-bg-slate-950 tw-px-3 tw-py-2">
+                      {path}
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <p className="tw-text-sm tw-text-slate-400">Run discovery to surface backlog entries and summary docs.</p>
+              )}
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/wizard/page.tsx
+++ b/app/wizard/page.tsx
@@ -1,0 +1,80 @@
+import Link from "next/link";
+
+import { WIZARD_ENTRY_POINTS } from "@/lib/wizard-entry-points";
+
+export default function WizardLandingPage() {
+  return (
+    <section className="tw-space-y-10">
+      <div className="tw-space-y-3">
+        <span className="tw-inline-flex tw-items-center tw-gap-2 tw-rounded-full tw-border tw-border-slate-800 tw-px-3 tw-py-1 tw-text-xs tw-font-medium tw-uppercase tw-tracking-wide tw-text-slate-300">
+          Product Wizard
+        </span>
+        <h1 className="tw-text-3xl tw-font-bold tw-leading-tight tw-text-slate-100">
+          Choose your starting point
+        </h1>
+        <p className="tw-text-lg tw-leading-relaxed tw-text-slate-300">
+          Match the wizard to your current milestone so the right roadmap, automations, and integrations spin up instantly.
+        </p>
+      </div>
+
+      <div className="tw-grid tw-gap-6 md:tw-grid-cols-2">
+        {WIZARD_ENTRY_POINTS.map((entry) => (
+          <div
+            key={entry.slug}
+            className="tw-rounded-3xl tw-border tw-border-slate-800 tw-bg-slate-900 tw-p-8 tw-flex tw-flex-col tw-gap-6 tw-h-full tw-transition tw-duration-200 tw-ease-out tw-transform hover:tw-border-slate-700 hover:tw-shadow-xl hover:tw-translate-y-[-4px]"
+          >
+            <div className="tw-inline-flex tw-items-center tw-gap-2 tw-text-xs tw-font-semibold tw-uppercase tw-tracking-wide tw-text-slate-300">
+              <span className="tw-inline-flex tw-items-center tw-justify-center tw-rounded-full tw-border tw-border-slate-800 tw-px-3 tw-py-1 tw-text-[0.7rem] tw-font-semibold tw-text-slate-100">
+                {entry.label}
+              </span>
+              <span className="tw-text-slate-400">Entry Point</span>
+            </div>
+
+            <div className="tw-space-y-2">
+              <h2 className="tw-text-2xl tw-font-semibold tw-leading-snug tw-text-slate-100">
+                {entry.title}
+              </h2>
+              <p className="tw-text-sm tw-leading-relaxed tw-text-slate-300">{entry.description}</p>
+            </div>
+
+            <ul className="tw-space-y-2 tw-text-sm tw-text-slate-300 tw-list-disc tw-pl-5">
+              {entry.bullets.map((bullet) => (
+                <li key={bullet} className="tw-leading-relaxed">
+                  {bullet}
+                </li>
+              ))}
+            </ul>
+
+            <div className="tw-flex tw-flex-wrap tw-items-center tw-gap-3">
+              <Link
+                href={`/wizard/${entry.slug}`}
+                className="tw-inline-flex tw-items-center tw-gap-2 tw-rounded-full tw-bg-slate-100 tw-px-4 tw-py-2 tw-text-sm tw-font-semibold tw-text-slate-900 tw-transition tw-duration-200 tw-ease-out hover:tw-bg-slate-200"
+              >
+                <span>View playbook</span>
+                <span aria-hidden="true">→</span>
+              </Link>
+              {entry.tools?.map((tool) => (
+                <Link
+                  key={tool.href}
+                  href={tool.href}
+                  className="tw-inline-flex tw-items-center tw-gap-2 tw-rounded-full tw-border tw-border-slate-700 tw-bg-slate-900 tw-px-4 tw-py-2 tw-text-sm tw-font-semibold tw-text-slate-200 tw-transition tw-duration-200 tw-ease-out hover:tw-border-slate-600 hover:tw-text-slate-100"
+                >
+                  <span>{tool.label}</span>
+                  <span aria-hidden="true">↗</span>
+                </Link>
+              ))}
+            </div>
+
+            {entry.tools?.map((tool) =>
+              tool.description ? (
+                <p key={`${tool.href}-note`} className="tw-text-xs tw-leading-relaxed tw-text-slate-400">
+                  {tool.description}
+                </p>
+              ) : null
+            )}
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/app/wizard/roadmap/page.tsx
+++ b/app/wizard/roadmap/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function RoadmapWorkspaceRedirect() {
+  redirect("/wizard/roadmap/workspace");
+}

--- a/app/wizard/roadmap/workspace/page.tsx
+++ b/app/wizard/roadmap/workspace/page.tsx
@@ -1,0 +1,336 @@
+"use client";
+
+import {
+  ChangeEvent,
+  FormEvent,
+  Suspense,
+  useMemo,
+  useState,
+} from "react";
+import Link from "next/link";
+import { useSearchParams } from "next/navigation";
+import { load } from "js-yaml";
+
+type ErrorState = { title: string; detail?: string } | null;
+type SuccessState = {
+  created: string[];
+  skipped: string[];
+  owner: string;
+  repo: string;
+} | null;
+
+type UploadState = {
+  name: string;
+  sizeLabel: string;
+};
+
+type ImportResponse = {
+  ok: boolean;
+  created?: string[];
+  skipped?: string[];
+  error?: string;
+  detail?: string;
+};
+
+function formatBytes(bytes: number) {
+  if (Number.isNaN(bytes) || bytes <= 0) {
+    return "0 B";
+  }
+  const units = ["B", "KB", "MB", "GB"];
+  let value = bytes;
+  let unitIndex = 0;
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024;
+    unitIndex += 1;
+  }
+  const precision = value < 10 && unitIndex > 0 ? 1 : 0;
+  return `${value.toFixed(precision)} ${units[unitIndex]}`;
+}
+
+function RoadmapProvisionerInner() {
+  const params = useSearchParams();
+  const [owner, setOwner] = useState(() => params.get("owner") ?? "");
+  const [repo, setRepo] = useState(() => params.get("repo") ?? "");
+  const [branch, setBranch] = useState(() => params.get("branch") ?? "main");
+  const [upload, setUpload] = useState<UploadState | null>(null);
+  const [roadmap, setRoadmap] = useState("");
+  const [error, setError] = useState<ErrorState>(null);
+  const [success, setSuccess] = useState<SuccessState>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [uploadKey, setUploadKey] = useState(0);
+
+  const roadmapPreview = useMemo(() => roadmap.trim(), [roadmap]);
+  const hasRoadmap = Boolean(roadmapPreview);
+  const canSubmit = Boolean(!isSubmitting && owner && repo && hasRoadmap);
+
+  async function handleFileChange(event: ChangeEvent<HTMLInputElement>) {
+    const file = event.target.files?.[0];
+    if (!file) {
+      setUpload(null);
+      setRoadmap("");
+      setSuccess(null);
+      setUploadKey((value) => value + 1);
+      return;
+    }
+
+    if (file.size > 2 * 1024 * 1024) {
+      setError({ title: "File too large", detail: "Limit uploads to 2MB roadmap files." });
+      event.target.value = "";
+      setUpload(null);
+      setRoadmap("");
+      setUploadKey((value) => value + 1);
+      return;
+    }
+
+    try {
+      const text = await file.text();
+      if (!text.trim()) {
+        throw new Error("Roadmap file is empty");
+      }
+      load(text);
+      setRoadmap(text.trimEnd());
+      setUpload({ name: file.name, sizeLabel: formatBytes(file.size) });
+      setError(null);
+      setSuccess(null);
+    } catch (err: any) {
+      setError({ title: "Invalid roadmap.yml", detail: err?.message ?? String(err) });
+      setUpload(null);
+      setRoadmap("");
+      setUploadKey((value) => value + 1);
+    }
+  }
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!canSubmit) {
+      setError({ title: "Provide required fields", detail: "Upload a roadmap and fill owner/repo before continuing." });
+      return;
+    }
+
+    setIsSubmitting(true);
+    setError(null);
+    setSuccess(null);
+
+    try {
+      const response = await fetch("/api/roadmap/import", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ owner, repo, branch, roadmap }),
+      });
+
+      const payload = (await response.json()) as ImportResponse;
+      if (!response.ok || !payload?.ok) {
+        const title = payload?.error ?? "Failed to import roadmap";
+        setError({ title, detail: payload?.detail });
+        return;
+      }
+
+      setSuccess({
+        created: payload.created ?? [],
+        skipped: payload.skipped ?? [],
+        owner,
+        repo,
+      });
+    } catch (err: any) {
+      setError({ title: "Request failed", detail: err instanceof Error ? err.message : String(err) });
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  const dashboardHref = success ? `/${success.owner}/${success.repo}` : null;
+
+  return (
+    <div className="tw-space-y-10">
+      <header className="tw-space-y-3">
+        <span className="tw-inline-flex tw-items-center tw-gap-2 tw-rounded-full tw-border tw-border-slate-800 tw-px-3 tw-py-1 tw-text-xs tw-font-medium tw-uppercase tw-tracking-wide tw-text-slate-300">
+          Roadmap provisioning
+        </span>
+        <h1 className="tw-text-3xl tw-font-bold tw-leading-tight tw-text-slate-100">
+          Import roadmap.yml and scaffold automations
+        </h1>
+        <p className="tw-text-base tw-leading-relaxed tw-text-slate-300">
+          Upload your finalized roadmap to sync docs/roadmap.yml, then generate the foundational artifacts that power status checks and team context.
+        </p>
+      </header>
+
+      <form onSubmit={handleSubmit} className="tw-grid tw-gap-8 lg:tw-grid-cols-[2fr,1fr]">
+        <section className="tw-space-y-6 tw-rounded-3xl tw-border tw-border-slate-800 tw-bg-slate-900 tw-p-8">
+          <div className="tw-grid tw-gap-4 md:tw-grid-cols-3">
+            <label className="tw-flex tw-flex-col tw-gap-2">
+              <span className="tw-text-sm tw-font-medium tw-text-slate-200">Owner</span>
+              <input
+                value={owner}
+                onChange={(event) => setOwner(event.target.value)}
+                placeholder="acme-co"
+                className="tw-w-full tw-rounded-xl tw-border tw-border-slate-700 tw-bg-slate-950 tw-px-3 tw-py-2 tw-text-sm tw-text-slate-100 tw-placeholder-slate-500 focus:tw-border-slate-500 focus:tw-outline-none"
+              />
+            </label>
+            <label className="tw-flex tw-flex-col tw-gap-2">
+              <span className="tw-text-sm tw-font-medium tw-text-slate-200">Repository</span>
+              <input
+                value={repo}
+                onChange={(event) => setRepo(event.target.value)}
+                placeholder="product-app"
+                className="tw-w-full tw-rounded-xl tw-border tw-border-slate-700 tw-bg-slate-950 tw-px-3 tw-py-2 tw-text-sm tw-text-slate-100 tw-placeholder-slate-500 focus:tw-border-slate-500 focus:tw-outline-none"
+              />
+            </label>
+            <label className="tw-flex tw-flex-col tw-gap-2">
+              <span className="tw-text-sm tw-font-medium tw-text-slate-200">Branch</span>
+              <input
+                value={branch}
+                onChange={(event) => setBranch(event.target.value)}
+                placeholder="main"
+                className="tw-w-full tw-rounded-xl tw-border tw-border-slate-700 tw-bg-slate-950 tw-px-3 tw-py-2 tw-text-sm tw-text-slate-100 tw-placeholder-slate-500 focus:tw-border-slate-500 focus:tw-outline-none"
+              />
+            </label>
+          </div>
+
+          <div className="tw-space-y-3">
+            <label htmlFor="roadmap-upload" className="tw-block tw-text-sm tw-font-medium tw-text-slate-200">
+              Upload docs/roadmap.yml
+            </label>
+            <input
+              key={uploadKey}
+              id="roadmap-upload"
+              type="file"
+              accept=".yml,.yaml"
+              onChange={handleFileChange}
+              className="tw-w-full tw-rounded-xl tw-border tw-border-dashed tw-border-slate-700 tw-bg-slate-950 tw-px-3 tw-py-3 tw-text-sm tw-text-slate-300 focus:tw-border-slate-500 focus:tw-outline-none"
+            />
+            {upload ? (
+              <div className="tw-flex tw-items-center tw-justify-between tw-rounded-xl tw-border tw-border-slate-800 tw-bg-slate-950 tw-px-4 tw-py-3">
+                <div>
+                  <p className="tw-text-sm tw-font-medium tw-text-slate-100">{upload.name}</p>
+                  <p className="tw-text-xs tw-text-slate-400">{upload.sizeLabel}</p>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setUpload(null);
+                    setRoadmap("");
+                    setSuccess(null);
+                    setUploadKey((value) => value + 1);
+                  }}
+                  className="tw-text-xs tw-font-semibold tw-text-slate-300 hover:tw-text-slate-100"
+                >
+                  Remove
+                </button>
+              </div>
+            ) : (
+              <p className="tw-text-xs tw-text-slate-400">
+                Accepts .yml or .yaml files up to 2MB. We validate the file with js-yaml before committing it to your repository.
+              </p>
+            )}
+          </div>
+
+          {hasRoadmap ? (
+            <div className="tw-space-y-2">
+              <div className="tw-flex tw-items-center tw-justify-between">
+                <h2 className="tw-text-base tw-font-semibold tw-text-slate-200">Preview</h2>
+                <span className="tw-text-xs tw-font-medium tw-text-emerald-400">Validated ✓</span>
+              </div>
+              <pre className="tw-max-h-72 tw-overflow-auto tw-rounded-2xl tw-border tw-border-slate-800 tw-bg-slate-950 tw-p-4 tw-text-xs tw-leading-relaxed tw-text-slate-200">
+                <code>{roadmapPreview}</code>
+              </pre>
+            </div>
+          ) : null}
+
+          {error ? (
+            <div className="tw-rounded-2xl tw-border tw-border-rose-800 tw-bg-rose-950/40 tw-p-4">
+              <h3 className="tw-text-sm tw-font-semibold tw-text-rose-200">{error.title}</h3>
+              {error.detail ? <p className="tw-text-xs tw-text-rose-300 tw-mt-1">{error.detail}</p> : null}
+            </div>
+          ) : null}
+
+          {success ? (
+            <div className="tw-rounded-2xl tw-border tw-border-emerald-700 tw-bg-emerald-950/40 tw-p-4 tw-space-y-2">
+              <h3 className="tw-text-sm tw-font-semibold tw-text-emerald-200">Roadmap imported successfully</h3>
+              <p className="tw-text-xs tw-text-emerald-100">
+                Created {success.created.length} files{success.skipped.length ? `, skipped ${success.skipped.length} existing` : ""}.
+              </p>
+              {dashboardHref ? (
+                <Link
+                  href={dashboardHref}
+                  className="tw-inline-flex tw-items-center tw-gap-2 tw-rounded-full tw-border tw-border-emerald-500 tw-bg-emerald-600/10 tw-px-3 tw-py-1.5 tw-text-xs tw-font-semibold tw-text-emerald-100 hover:tw-bg-emerald-600/20"
+                >
+                  View dashboard
+                  <span aria-hidden="true">↗</span>
+                </Link>
+              ) : null}
+            </div>
+          ) : null}
+
+          <div className="tw-flex tw-items-center tw-gap-3">
+            <button
+              type="submit"
+              disabled={!canSubmit}
+              className="tw-inline-flex tw-items-center tw-justify-center tw-rounded-full tw-bg-slate-100 tw-px-5 tw-py-2.5 tw-text-sm tw-font-semibold tw-text-slate-900 tw-transition tw-duration-200 tw-ease-out disabled:tw-cursor-not-allowed disabled:tw-bg-slate-500/50"
+            >
+              {isSubmitting ? "Importing…" : "Import & scaffold"}
+            </button>
+            <p className="tw-text-xs tw-text-slate-400">
+              We will commit docs/roadmap.yml and scaffold supporting artifacts directly to {branch}.
+            </p>
+          </div>
+        </section>
+
+        <aside className="tw-space-y-6 tw-rounded-3xl tw-border tw-border-slate-800 tw-bg-slate-950 tw-p-8">
+          <div className="tw-space-y-2">
+            <h2 className="tw-text-lg tw-font-semibold tw-text-slate-100">What gets created</h2>
+            <p className="tw-text-sm tw-text-slate-300">
+              In addition to syncing docs/roadmap.yml, we provision supporting files that keep your roadmap connected to infra, tech stack, and automation workflows.
+            </p>
+          </div>
+          <ul className="tw-space-y-4">
+            <li className="tw-rounded-2xl tw-border tw-border-slate-800 tw-bg-slate-900 tw-p-4">
+              <h3 className="tw-text-sm tw-font-semibold tw-text-slate-100">docs/infra-facts.md</h3>
+              <p className="tw-text-xs tw-text-slate-300">
+                Capture deployment constraints, database configuration, and escalation paths so handoffs stay smooth once build work begins.
+              </p>
+            </li>
+            <li className="tw-rounded-2xl tw-border tw-border-slate-800 tw-bg-slate-900 tw-p-4">
+              <h3 className="tw-text-sm tw-font-semibold tw-text-slate-100">docs/tech-stack.yml</h3>
+              <p className="tw-text-xs tw-text-slate-300">
+                Fill in frameworks, services, and integrations to give AI copilots and collaborators a consistent view of your stack.
+              </p>
+            </li>
+            <li className="tw-rounded-2xl tw-border tw-border-slate-800 tw-bg-slate-900 tw-p-4">
+              <h3 className="tw-text-sm tw-font-semibold tw-text-slate-100">.github/workflows/roadmap.yml</h3>
+              <p className="tw-text-xs tw-text-slate-300">
+                Runs roadmap checks on pushes and pull requests, wiring status updates into the dashboard.
+              </p>
+            </li>
+          </ul>
+          <div className="tw-rounded-2xl tw-border tw-border-slate-800 tw-bg-slate-900 tw-p-4 tw-space-y-2">
+            <h3 className="tw-text-sm tw-font-semibold tw-text-slate-100">Need the dashboard link?</h3>
+            <p className="tw-text-xs tw-text-slate-300">
+              After import, jump straight to the live dashboard for this repository to confirm status feeds and roadmap context are flowing.
+            </p>
+            {dashboardHref ? (
+              <Link
+                href={dashboardHref}
+                className="tw-inline-flex tw-items-center tw-gap-2 tw-rounded-full tw-border tw-border-slate-700 tw-bg-slate-900 tw-px-3 tw-py-1.5 tw-text-xs tw-font-semibold tw-text-slate-200 hover:tw-border-slate-500"
+              >
+                Open {success?.owner}/{success?.repo}
+                <span aria-hidden="true">↗</span>
+              </Link>
+            ) : (
+              <p className="tw-text-xs tw-text-slate-500">Link will appear after a successful import.</p>
+            )}
+          </div>
+        </aside>
+      </form>
+    </div>
+  );
+}
+
+function RoadmapProvisionerPage() {
+  return (
+    <Suspense fallback={<div className="tw-text-slate-300">Loading roadmap wizard…</div>}>
+      <RoadmapProvisionerInner />
+    </Suspense>
+  );
+}
+
+export default RoadmapProvisionerPage;

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -126,3 +126,32 @@ export async function putFile(
   return r.json();
 }
 
+export async function listRepoTree(
+  owner: string,
+  repo: string,
+  ref = "HEAD",
+  token?: string
+) {
+  const t = token ?? (await ghToken(false));
+  const url =
+    `https://api.github.com/repos/${owner}/${repo}/git/trees/${encodeURIComponent(ref)}` +
+    "?recursive=1";
+  const r = await fetch(url, { headers: ghHeaders(t, "json"), cache: "no-store" });
+  if (r.status === 404) return [] as string[];
+  if (r.status === 401) {
+    if (!t) throw new Error(`GitHub 401 (set GITHUB_TOKEN with access to ${owner}/${repo})`);
+    throw new Error(`GitHub 401 (check PAT scope/access for ${owner}/${repo})`);
+  }
+  if (!r.ok) {
+    const txt = await r.text();
+    throw new Error(`GET tree ${owner}/${repo}@${ref} failed: ${r.status} ${txt}`);
+  }
+
+  const json = (await r.json()) as { tree?: Array<{ type?: string; path?: string }> };
+  if (!json?.tree) return [] as string[];
+  return json.tree
+    .filter((node) => node?.type === "blob" && typeof node?.path === "string")
+    .map((node) => node.path!)
+    .sort();
+}
+

--- a/lib/wizard-entry-points.ts
+++ b/lib/wizard-entry-points.ts
@@ -1,0 +1,94 @@
+export type WizardEntryTool = {
+  href: string;
+  label: string;
+  description?: string;
+};
+
+export type WizardEntryPoint = {
+  slug: string;
+  label: string;
+  title: string;
+  description: string;
+  bullets: readonly string[];
+  tools?: readonly WizardEntryTool[];
+};
+
+export const WIZARD_ENTRY_POINTS: readonly WizardEntryPoint[] = [
+  {
+    slug: "new-idea",
+    label: "Ideate",
+    title: "New Idea Brainstorming",
+    description:
+      "Open a persistent AI ideation hub that captures every spark, note, and inspiration so nothing gets lost between sessions.",
+    bullets: [
+      "Start a project-linked conversation that keeps your brainstorming history in sync.",
+      "Clip research, voice notes, and quick sketches into a living idea vault.",
+      "Upgrade the flow into a roadmap whenever you are ready to commit.",
+    ],
+    tools: [
+      {
+        href: "/wizard/brainstorm",
+        label: "Launch idea workspace",
+        description: "Open the AI chat that logs every turn and can be promoted into docs/idea-log.md.",
+      },
+    ],
+  },
+  {
+    slug: "concept",
+    label: "Design",
+    title: "Firm Concept, Missing Roadmap",
+    description:
+      "Transform your concept brief into a structured roadmap with generated files, integrations, and connection points.",
+    bullets: [
+      "Import an existing AI chat or upload your concept write-up for instant context.",
+      "Co-create an actionable roadmap and scaffold repo-ready artifacts in one click.",
+      "Wire up Supabase, secrets, and GitHub so your execution stack is ready to ship.",
+    ],
+    tools: [
+      {
+        href: "/wizard/concept/workspace",
+        label: "Open roadmap drafting workspace",
+        description: "Paste your brief or upload a file, generate docs/roadmap.yml, and commit it to the repo.",
+      },
+    ],
+  },
+  {
+    slug: "roadmap-ready",
+    label: "Launch",
+    title: "Roadmap Ready, Pre-Build",
+    description:
+      "Drop in an existing roadmap and let the wizard provision your repo, automations, and context packs automatically.",
+    bullets: [
+      "Upload roadmap docs and sync the structure into docs/roadmap.yml.",
+      "Generate GTM, tech stack, and infra snapshots that stay aligned with the plan.",
+      "Push the new workspace to GitHub with secrets and integrations configured.",
+    ],
+    tools: [
+      {
+        href: "/wizard/roadmap/workspace",
+        label: "Launch provisioning workspace",
+        description:
+          "Upload an existing roadmap.yml, validate it, and scaffold infra-facts, tech stack, and roadmap workflow files.",
+      },
+    ],
+  },
+  {
+    slug: "mid-build",
+    label: "Scale",
+    title: "Mid-Project Build",
+    description:
+      "Layer discovery mode on top of your active repo so AI copilots see progress, regressions, and the next best action.",
+    bullets: [
+      "Ingest repo history, Supabase schema, and roadmap status into a unified context pack.",
+      "Surface off-roadmap work automatically so nothing gets lost in the shuffle.",
+      "Hand the full context to your AI teammate or keep coding with richer feedback.",
+    ],
+    tools: [
+      {
+        href: "/wizard/midproject/workspace",
+        label: "Launch mid-project sync",
+        description: "Run status + discover workflows and preview backlog discoveries before opening the dashboard.",
+      },
+    ],
+  },
+] as const;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.3.0",
       "dependencies": {
         "jose": "^5.10.0",
+        "micromatch": "^4.0.8",
         "js-yaml": "^4.1.0",
         "jsonwebtoken": "^9.0.2",
         "next": "^14.2.32",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "jose": "^5.10.0",
+    "micromatch": "^4.0.8",
     "js-yaml": "^4.1.0",
     "jsonwebtoken": "^9.0.2",
     "next": "^14.2.32",

--- a/types/micromatch.d.ts
+++ b/types/micromatch.d.ts
@@ -1,0 +1,15 @@
+declare module "micromatch" {
+  export interface MicromatchOptions {
+    dot?: boolean;
+    nocase?: boolean;
+    nobrace?: boolean;
+    noglobstar?: boolean;
+    [key: string]: unknown;
+  }
+
+  export default function micromatch(
+    list: string[] | string,
+    patterns: string | string[],
+    options?: MicromatchOptions,
+  ): string[];
+}


### PR DESCRIPTION
## Summary
- point the mid-project playbook discovery shortcut at the sync workspace instead of the raw API to avoid 405s
- add an in-page anchor on the backlog panel so the updated link scrolls users directly to the discovery results

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de7d44be18832d996ca1abd0348a3b