### PR TITLE
Add multi-project selection to wizard workspaces

### DIFF
--- a/app/api/brainstorm/chat/route.ts
+++ b/app/api/brainstorm/chat/route.ts
@@ -1,0 +1,124 @@
+import { NextResponse } from "next/server";
+import fs from "fs/promises";
+import path from "path";
+
+type ClientMessage = {
+  role: "user" | "assistant";
+  content: string;
+};
+
+type ChatRequestBody = {
+  conversationId?: string;
+  history?: ClientMessage[];
+  message?: string;
+};
+
+const SYSTEM_PROMPT =
+  "You are an ideation partner helping founders expand product ideas into detailed opportunities. " +
+  "Ask clarifying questions, suggest adjacent opportunities, and help them shape a concept into something actionable.";
+
+async function ensureIdeasFile(conversationId: string) {
+  const ideasDir = path.join("/tmp", "ideas");
+  await fs.mkdir(ideasDir, { recursive: true });
+  const filePath = path.join(ideasDir, `${conversationId}.md`);
+  try {
+    await fs.access(filePath);
+  } catch {
+    const header = `# Brainstorm Session ${conversationId}\n\n`;
+    await fs.writeFile(filePath, header, "utf8");
+  }
+  return filePath;
+}
+
+function normalizeHistory(history?: ClientMessage[]): ClientMessage[] {
+  if (!Array.isArray(history)) {
+    return [];
+  }
+
+  return history
+    .filter((message): message is ClientMessage => {
+      if (!message || typeof message !== "object") {
+        return false;
+      }
+      return (message.role === "user" || message.role === "assistant") && typeof message.content === "string";
+    })
+    .map((message) => ({
+      role: message.role,
+      content: message.content.trim(),
+    }));
+}
+
+export async function POST(req: Request) {
+  let body: ChatRequestBody;
+
+  try {
+    body = await req.json();
+  } catch (error) {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const headerKey = req.headers.get("x-openai-key")?.trim();
+  const openAiKey = headerKey || process.env.OPENAI_API_KEY;
+
+  if (!openAiKey) {
+    return NextResponse.json(
+      {
+        error: "OpenAI API key is not configured",
+        detail: "Add a key in Settings so the wizard can call OpenAI.",
+      },
+      { status: 500 },
+    );
+  }
+
+  const history = normalizeHistory(body.history);
+  const userMessage = typeof body.message === "string" ? body.message.trim() : "";
+
+  if (!userMessage) {
+    return NextResponse.json({ error: "Message is required" }, { status: 400 });
+  }
+
+  const conversationId = body.conversationId?.trim() || Date.now().toString();
+
+  const payload = {
+    model: "gpt-4o-mini",
+    messages: [
+      { role: "system", content: SYSTEM_PROMPT },
+      ...history,
+      { role: "user", content: userMessage },
+    ],
+  };
+
+  const response = await fetch("https://api.openai.com/v1/chat/completions", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${openAiKey}`,
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    return NextResponse.json(
+      { error: "Failed to reach OpenAI", detail: errorText.slice(0, 400) },
+      { status: response.status },
+    );
+  }
+
+  const data = (await response.json()) as {
+    choices?: Array<{ message?: { content?: string } }>;
+  };
+
+  const reply = data.choices?.[0]?.message?.content?.trim();
+
+  if (!reply) {
+    return NextResponse.json({ error: "OpenAI response was empty" }, { status: 502 });
+  }
+
+  const filePath = await ensureIdeasFile(conversationId);
+  const timestamp = new Date().toISOString();
+  const entry = `## ${timestamp}\n\n### User\n${userMessage}\n\n### Assistant\n${reply}\n\n`;
+  await fs.appendFile(filePath, entry, "utf8");
+
+  return NextResponse.json({ conversationId, reply });
+}

--- a/app/api/brainstorm/promote/route.ts
+++ b/app/api/brainstorm/promote/route.ts
@@ -1,0 +1,85 @@
+import { NextResponse } from "next/server";
+import fs from "fs/promises";
+import path from "path";
+
+type ClientMessage = {
+  role: "user" | "assistant";
+  content: string;
+};
+
+type PromoteRequestBody = {
+  conversationId?: string;
+  messages?: ClientMessage[];
+};
+
+function normalizeMessages(messages?: ClientMessage[]): ClientMessage[] {
+  if (!Array.isArray(messages)) {
+    return [];
+  }
+
+  return messages
+    .filter((message): message is ClientMessage => {
+      if (!message || typeof message !== "object") {
+        return false;
+      }
+      return (message.role === "user" || message.role === "assistant") && typeof message.content === "string";
+    })
+    .map((message) => ({
+      role: message.role,
+      content: message.content.trim(),
+    }));
+}
+
+function formatTranscript(messages: ClientMessage[]): string {
+  return messages
+    .map((message, index) => {
+      const speaker = message.role === "user" ? "Founder" : "AI Partner";
+      const formattedContent = message.content.replace(/\n/g, "\n  ");
+      return `${index + 1}. **${speaker}:** ${formattedContent}`;
+    })
+    .join("\n");
+}
+
+export async function POST(req: Request) {
+  let body: PromoteRequestBody;
+
+  try {
+    body = await req.json();
+  } catch (error) {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const messages = normalizeMessages(body.messages);
+
+  if (messages.length === 0) {
+    return NextResponse.json({ error: "No messages to export" }, { status: 400 });
+  }
+
+  const conversationId = body.conversationId?.trim();
+  const timestamp = new Date().toISOString();
+
+  const docsDir = path.join(process.cwd(), "docs");
+  await fs.mkdir(docsDir, { recursive: true });
+  const ideaLogPath = path.join(docsDir, "idea-log.md");
+
+  let content = "";
+  try {
+    await fs.access(ideaLogPath);
+  } catch {
+    content += "# Idea Log\n\n";
+  }
+
+  const sessionHeaderParts = [
+    `## Session promoted on ${timestamp}`,
+    conversationId ? `Session ID: ${conversationId}` : undefined,
+    "",
+  ].filter(Boolean);
+
+  const transcript = formatTranscript(messages);
+
+  content += `${sessionHeaderParts.join("\n")}\n${transcript}\n\n`;
+
+  await fs.appendFile(ideaLogPath, content, "utf8");
+
+  return NextResponse.json({ ok: true, path: "docs/idea-log.md" });
+}

--- a/app/api/concept/commit/route.ts
+++ b/app/api/concept/commit/route.ts
@@ -1,0 +1,62 @@
+import { NextResponse } from "next/server";
+
+import { putFile } from "@/lib/github";
+import { describeProjectFile, normalizeProjectKey, projectAwarePath } from "@/lib/project-paths";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function POST(req: Request) {
+  try {
+    const url = new URL(req.url);
+    const asPR = url.searchParams.get("asPR") === "true";
+    const body = await req.json();
+    const owner = typeof body?.owner === "string" ? body.owner.trim() : "";
+    const repo = typeof body?.repo === "string" ? body.repo.trim() : "";
+    const branch = typeof body?.branch === "string" && body.branch.trim() ? body.branch.trim() : "main";
+    const content = typeof body?.content === "string" ? body.content : "";
+    const projectInput = typeof body?.project === "string" ? body.project : "";
+    const projectKey = normalizeProjectKey(projectInput);
+    const token = req.headers.get("x-github-pat")?.trim() || undefined;
+
+    if (!owner || !repo) {
+      return NextResponse.json({ error: "owner and repo are required" }, { status: 400 });
+    }
+
+    if (!content.trim()) {
+      return NextResponse.json({ error: "Roadmap content is empty" }, { status: 400 });
+    }
+
+    const targetPath = projectAwarePath("docs/roadmap.yml", projectKey);
+    const message = projectKey
+      ? `feat(${projectKey}): add generated ${describeProjectFile("docs/roadmap.yml", projectKey)}`
+      : "feat(roadmap): add generated docs/roadmap.yml";
+    const result = await putFile(
+      owner,
+      repo,
+      targetPath,
+      content,
+      branch,
+      message,
+      token,
+      asPR
+        ? {
+            asPR: true,
+            prTitle: message,
+            prBody:
+              "Generated via Concept to Roadmap wizard. Review the roadmap structure and merge when ready.",
+          }
+        : undefined,
+    );
+
+    return NextResponse.json({
+      ok: true,
+      branch: result.branch,
+      prUrl: result.pullRequest?.html_url ?? result.pullRequest?.url,
+      pullRequestNumber: result.pullRequest?.number,
+      path: targetPath,
+    });
+  } catch (error: any) {
+    return NextResponse.json({ error: error?.message ?? "Failed to commit roadmap" }, { status: 500 });
+  }
+}

--- a/app/api/concept/generate/route.ts
+++ b/app/api/concept/generate/route.ts
@@ -1,0 +1,86 @@
+import { NextResponse } from "next/server";
+
+const SYSTEM_PROMPT = "Generate a YAML roadmap with weeks/items in docs/roadmap.yml format.";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+function normalizeInput(value: unknown): string {
+  if (typeof value === "string") {
+    return value.trim();
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry) => normalizeInput(entry)).filter(Boolean).join("\n\n");
+  }
+  if (value && typeof value === "object") {
+    return normalizeInput(Object.values(value));
+  }
+  return "";
+}
+
+export async function POST(req: Request) {
+  try {
+    const body = await req.json().catch(() => ({}));
+    const prompt = normalizeInput((body as { prompt?: unknown })?.prompt);
+
+    if (!prompt) {
+      return NextResponse.json({ error: "Provide concept text or an uploaded document" }, { status: 400 });
+    }
+
+    const headerKey = req.headers.get("x-openai-key")?.trim();
+    const apiKey = headerKey || process.env.OPENAI_API_KEY;
+    if (!apiKey) {
+      return NextResponse.json(
+        {
+          error: "OpenAI API key is not configured",
+          detail: "Add a key in Settings so the wizard can generate a roadmap.",
+        },
+        { status: 500 },
+      );
+    }
+
+    const payload = {
+      model: "gpt-4o-mini",
+      messages: [
+        { role: "system", content: SYSTEM_PROMPT },
+        {
+          role: "user",
+          content:
+            "Context from founder or product lead describing the concept. Generate docs/roadmap.yml YAML.\n\n" + prompt,
+        },
+      ],
+      temperature: 0.2,
+    };
+
+    const response = await fetch("https://api.openai.com/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      return NextResponse.json(
+        { error: "Failed to generate roadmap", detail: errorText.slice(0, 400) },
+        { status: response.status },
+      );
+    }
+
+    const data = (await response.json()) as {
+      choices?: Array<{ message?: { content?: string | null } }>;
+    };
+
+    const roadmap = data.choices?.[0]?.message?.content?.trim();
+
+    if (!roadmap) {
+      return NextResponse.json({ error: "OpenAI response was empty" }, { status: 502 });
+    }
+
+    return NextResponse.json({ roadmap });
+  } catch (error: any) {
+    return NextResponse.json({ error: error?.message ?? "Unexpected error" }, { status: 500 });
+  }
+}

--- a/app/api/context/[owner]/[repo]/route.ts
+++ b/app/api/context/[owner]/[repo]/route.ts
@@ -1,0 +1,89 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { getFileRaw } from "@/lib/github";
+import { describeProjectFile, normalizeProjectKey, projectAwarePath } from "@/lib/project-paths";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+type RouteParams = { params: { owner: string; repo: string } };
+
+type ContextPackFile = {
+  path: string;
+  optional?: boolean;
+};
+
+const CONTEXT_FILES: ContextPackFile[] = [
+  { path: "docs/roadmap.yml" },
+  { path: "docs/roadmap-status.json" },
+  { path: "docs/tech-stack.yml" },
+  { path: "docs/backlog-discovered.yml" },
+  { path: "docs/summary.txt" },
+  { path: "docs/gtm-plan.md", optional: true },
+];
+
+function normalizeBranch(value: string | null): string | undefined {
+  if (!value) return undefined;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+export async function GET(req: NextRequest, { params }: RouteParams) {
+  const { owner, repo } = params;
+  const url = new URL(req.url);
+  const branch = normalizeBranch(url.searchParams.get("branch"));
+  const projectKey = normalizeProjectKey(url.searchParams.get("project"));
+
+  try {
+    const token = req.headers.get("x-github-pat")?.trim() || undefined;
+
+    const entries = await Promise.all(
+      CONTEXT_FILES.map(async (file) => ({
+        path: describeProjectFile(file.path, projectKey),
+        optional: file.optional ?? false,
+        content: await getFileRaw(owner, repo, projectAwarePath(file.path, projectKey), branch, token),
+      })),
+    );
+
+    const missing = entries
+      .filter((entry) => !entry.optional && entry.content === null)
+      .map((entry) => entry.path);
+
+    if (missing.length > 0) {
+      return NextResponse.json(
+        {
+          error: "missing_required_files",
+          missing,
+        },
+        { status: 404 },
+      );
+    }
+
+    const files: Record<string, string> = {};
+    for (const entry of entries) {
+      if (typeof entry.content === "string") {
+        files[entry.path] = entry.content;
+      }
+    }
+
+    const payload = {
+      generated_at: new Date().toISOString(),
+      repo: {
+        owner,
+        name: repo,
+        branch: branch ?? "HEAD",
+        project: projectKey || undefined,
+      },
+      files,
+    };
+
+    return NextResponse.json(payload);
+  } catch (error: any) {
+    return NextResponse.json(
+      {
+        error: error?.message ?? "Failed to build context pack",
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/discover/route.ts
+++ b/app/api/discover/route.ts
@@ -3,126 +3,363 @@ export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 import { NextRequest, NextResponse } from "next/server";
-import { getFileRaw, putFile } from "@/lib/github";
+import micromatch from "micromatch";
+import yaml from "js-yaml";
 
-// --- helpers ---
-async function probe(probeUrl: string, queries: string[]) {
-  if (!probeUrl) return queries.map(q => ({ q, ok: false, why: "no probeUrl" }));
-  const r = await fetch(probeUrl, {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({ queries })
-  });
-  if (!r.ok) return queries.map(q => ({ q, ok: false, why: String(r.status) }));
-  const j = await r.json().catch(() => ({}));
-  const arr = Array.isArray(j.results) ? j.results : [];
-  const byQ = new Map(arr.map((x: any) => [x.q, !!x.ok]));
-  return queries.map(q => ({ q, ok: !!byQ.get(q) }));
+import { getFileRaw, listRepoTreePaths, putFile } from "@/lib/github";
+import { describeProjectFile, normalizeProjectKey, projectAwarePath } from "@/lib/project-paths";
+
+const READ_ONLY_CHECKS_URL = process.env.READ_ONLY_CHECKS_URL || "";
+
+const DEFAULT_DB_QUERIES = ["ext:pgcrypto"];
+const DEFAULT_CODE_GLOBS = ["src/screens/**/*.{tsx,ts}"];
+const DEFAULT_DISCOVER_YAML = `# docs/discover.yml
+# Customize these queries and code globs to surface completed work
+# that never landed on your roadmap.
+db_queries:
+  - ext:pgcrypto
+code_globs:
+  - src/screens/**/*.{tsx,ts}
+`;
+
+type ProbeResult = { q: string; ok: boolean; why?: string };
+type DiscoverConfig = {
+  db_queries: string[];
+  code_globs: string[];
+  notes: string[];
+};
+
+type BacklogItem = { id: string; title: string; status: "complete" };
+
+type DiscoverSummary = {
+  owner: string;
+  repo: string;
+  branch: string;
+  project?: string;
+  config: DiscoverConfig;
+  dbSuccesses: string[];
+  dbFailures: ProbeResult[];
+  matchedPaths: string[];
+  discovered: BacklogItem[];
+};
+
+function ensureStringList(value: unknown, fallback: string[]): string[] {
+  if (!Array.isArray(value)) return fallback;
+  const filtered = value
+    .map((item) => (typeof item === "string" ? item.trim() : ""))
+    .filter((item) => item.length > 0);
+  return filtered.length ? filtered : fallback;
 }
 
-async function fileExists(owner: string, repo: string, path: string, ref?: string) {
-  // We treat each path as literal (cheap existence check via contents API/raw)
-  const raw = await getFileRaw(owner, repo, path, ref).catch(() => null);
-  return raw !== null;
-}
-
-function yamlList(items: { id: string; title: string; status: "complete" }[]) {
-  if (!items.length) {
-    return "# Auto-discovered items that appear complete but weren’t on the roadmap\n# (none)\n";
+async function probeSupabase(queries: string[], overrideUrl?: string): Promise<ProbeResult[]> {
+  const url = overrideUrl?.trim() || READ_ONLY_CHECKS_URL;
+  if (!url) {
+    return queries.map((q) => ({ q, ok: false, why: "READ_ONLY_CHECKS_URL not configured" }));
   }
-  return (
-    ["# Auto-discovered items that appear complete but weren’t on the roadmap"]
-      .concat(items.map(x => `- id: ${x.id}\n  title: "${x.title}"\n  status: complete`))
-      .join("\n") + "\n"
+
+  try {
+    const response = await fetch(url, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ queries }),
+    });
+
+    if (!response.ok) {
+      const detail = await response
+        .text()
+        .then((text) => text.trim())
+        .catch(() => "");
+      const why = detail ? `${response.status} ${detail}` : String(response.status);
+      return queries.map((q) => ({ q, ok: false, why }));
+    }
+
+    const json = await response.json().catch(() => ({}));
+    const arr = Array.isArray(json?.results) ? json.results : [];
+    const byQuery = new Map(arr.map((entry: any) => [entry?.q, !!entry?.ok]));
+    return queries.map((q) => ({ q, ok: !!byQuery.get(q) }));
+  } catch (error: any) {
+    return queries.map((q) => ({ q, ok: false, why: error?.message || String(error) }));
+  }
+}
+
+function parseDiscoverConfig(raw: string | null, pathLabel: string): DiscoverConfig {
+  const notes: string[] = [];
+
+  if (!raw) {
+    notes.push(`${pathLabel} not found — using defaults`);
+    return { db_queries: DEFAULT_DB_QUERIES, code_globs: DEFAULT_CODE_GLOBS, notes };
+  }
+
+  try {
+    const parsed = yaml.load(raw) as any;
+    const dbQueries = ensureStringList(parsed?.db_queries ?? parsed?.dbQueries, DEFAULT_DB_QUERIES);
+    const codeGlobs = ensureStringList(parsed?.code_globs ?? parsed?.codeGlobs, DEFAULT_CODE_GLOBS);
+    return { db_queries: dbQueries, code_globs: codeGlobs, notes };
+  } catch (error: any) {
+    notes.push(`Failed to parse ${pathLabel} (${error?.message || String(error)})`);
+    return { db_queries: DEFAULT_DB_QUERIES, code_globs: DEFAULT_CODE_GLOBS, notes };
+  }
+}
+
+function slugify(input: string) {
+  return input
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 64) || "item";
+}
+
+function backlogYaml(items: BacklogItem[], configPath: string) {
+  if (!items.length) {
+    return [
+      `# Auto-discovered items generated from ${configPath}`,
+      "# (none detected)",
+      "",
+    ].join("\n");
+  }
+
+  return [
+    `# Auto-discovered items generated from ${configPath}`,
+    ...items.map((item) => `- id: ${item.id}\n  title: "${item.title.replace(/"/g, '\\"')}"\n  status: complete`),
+    "",
+  ].join("\n");
+}
+
+function buildSummary(details: DiscoverSummary) {
+  const { owner, repo, branch, project, config, dbSuccesses, dbFailures, matchedPaths, discovered } = details;
+  const lines: string[] = [
+    `Repo: ${owner}/${repo}`,
+    ...(project ? [`Project: ${project}`] : []),
+    `Branch: ${branch}`,
+    `Generated: ${new Date().toISOString()}`,
+    "",
+    "Discovery configuration:",
+    `- db_queries (${config.db_queries.length}): ${config.db_queries.join(", ") || "(none)"}`,
+    `- code_globs (${config.code_globs.length}): ${config.code_globs.join(", ") || "(none)"}`,
+  ];
+
+  if (config.notes.length) {
+    lines.push("", "Notes:", ...config.notes.map((note) => `- ${note}`));
+  }
+
+  lines.push(
+    "",
+    `Successful database probes (${dbSuccesses.length}):`,
+    dbSuccesses.length ? dbSuccesses.map((q) => `- ${q}`).join("\n") : "- none",
+    "",
+    `Failed database probes (${dbFailures.length}):`,
+    dbFailures.length ? dbFailures.map((r) => `- ${r.q}${r.why ? ` → ${r.why}` : ""}`).join("\n") : "- none",
+    "",
+    `Matched code paths (${matchedPaths.length}):`,
+    matchedPaths.length ? matchedPaths.map((path) => `- ${path}`).join("\n") : "- none",
+    "",
+    `Newly discovered backlog items (${discovered.length}):`,
+    discovered.length ? discovered.map((item) => `- ${item.title}`).join("\n") : "- none",
+    "",
   );
+
+  return lines.join("\n");
+}
+
+function alreadyTrackedFactory(doneNames: Set<string>) {
+  const comparisons = Array.from(doneNames)
+    .map((name) => name.toLowerCase())
+    .filter(Boolean);
+
+  return (title: string) => {
+    const lower = title.toLowerCase();
+    return comparisons.some((name) => lower === name || lower.includes(name));
+  };
+}
+
+async function safePut(
+  owner: string,
+  repo: string,
+  branch: string,
+  path: string,
+  content: string,
+  message: string,
+  wrote: string[],
+  failures: string[],
+  token?: string,
+) {
+  try {
+    await putFile(owner, repo, path, content, branch, message, token);
+    wrote.push(path);
+  } catch (error: any) {
+    const detail = error?.message || String(error);
+    wrote.push(`${path} (FAILED: ${detail})`);
+    failures.push(`${path}: ${detail}`);
+  }
 }
 
 export async function POST(req: NextRequest) {
   try {
-    const { owner, repo, branch = "main", probeUrl } = await req.json();
+    const payload = await req.json();
+    const owner = typeof payload?.owner === "string" ? payload.owner.trim() : "";
+    const repo = typeof payload?.repo === "string" ? payload.repo.trim() : "";
+    const branch = typeof payload?.branch === "string" && payload.branch.trim() ? payload.branch.trim() : "main";
+    const probeUrl = typeof payload?.probeUrl === "string" ? payload.probeUrl : undefined;
+    const projectKey = normalizeProjectKey(payload?.project);
+    const token = req.headers.get("x-github-pat")?.trim() || undefined;
     if (!owner || !repo) {
       return NextResponse.json({ error: "missing owner/repo" }, { status: 400 });
     }
 
-    // 1) Read current status to avoid duplicating already-done items
-    const statusRaw = await getFileRaw(owner, repo, "docs/roadmap-status.json", branch).catch(() => null);
+    const wrote: string[] = [];
+    const failures: string[] = [];
+
+    const statusRaw = await getFileRaw(
+      owner,
+      repo,
+      projectAwarePath("docs/roadmap-status.json", projectKey),
+      branch,
+      token,
+    ).catch(() => null);
     const doneNames = new Set<string>();
     if (statusRaw) {
       try {
-        const s = JSON.parse(statusRaw);
-        for (const w of s.weeks ?? []) {
-          for (const it of w.items ?? []) {
-            if (it?.done && typeof it?.name === "string") doneNames.add(it.name);
+        const parsed = JSON.parse(statusRaw);
+        for (const week of parsed?.weeks ?? []) {
+          for (const item of week?.items ?? []) {
+            if (item?.done && typeof item?.name === "string") {
+              doneNames.add(item.name);
+            }
           }
         }
       } catch {}
     }
 
-    // 2) DB probes (edit this list to fit your schema/policies)
-    const dbQueries = [
-      "ext:pgcrypto",
-      "table:public:profiles",
-      "rls:public:profiles",
-      // Example policy (rename to match your policy names):
-      "policy:public:profiles:select:Profiles can view own"
-    ];
-    const db = await probe(probeUrl, dbQueries);
+    const discoverPath = projectAwarePath("docs/discover.yml", projectKey);
+    const discoverLabel = describeProjectFile("docs/discover.yml", projectKey);
+    const discoverRaw = await getFileRaw(owner, repo, discoverPath, branch, token).catch(() => null);
+    const missingDiscover = !discoverRaw;
+    const config = parseDiscoverConfig(discoverRaw, discoverLabel);
 
-    // 3) Code presence checks (add paths that matter for your repos)
-    const codePaths = [
-      "supabase/functions/read_only_checks/index.ts",
-      "src/screens/JournalScreen.tsx",
-      "docs/context/context-pack.json",
-      "docs/tech-stack.yml"
-    ];
-    const present: string[] = [];
-    for (const p of codePaths) {
-      // eslint-disable-next-line no-await-in-loop
-      if (await fileExists(owner, repo, p, branch)) present.push(p);
+    if (missingDiscover) {
+      await safePut(
+        owner,
+        repo,
+        branch,
+        discoverPath,
+        DEFAULT_DISCOVER_YAML,
+        projectKey
+          ? `chore(${projectKey}): seed discover config [skip ci]`
+          : "chore(roadmap): seed discover config [skip ci]",
+        wrote,
+        failures,
+        token,
+      );
+      config.notes.push(
+        `Seeded ${describeProjectFile("docs/discover.yml", projectKey)} with default discovery settings. Update this file to refine probes.`,
+      );
     }
 
-    // 4) Build discovered list, skipping names already “done” in status
-    const discovered: { id: string; title: string; status: "complete" }[] = [];
+    const dbResults = await probeSupabase(config.db_queries, probeUrl);
+    const dbSuccesses = dbResults.filter((result) => result.ok).map((result) => result.q);
+    const dbFailures = dbResults.filter((result) => !result.ok);
 
-    for (const r of db) {
-      if (r.ok) {
-        const title = `DB: ${r.q}`;
-        if (![...doneNames].some(n => title.includes(n))) {
-          discovered.push({ id: r.q.replace(/[^a-zA-Z0-9_-]+/g, "-"), title, status: "complete" });
-        }
-      }
-    }
-    for (const p of present) {
-      const title = `Code: ${p} present`;
-      if (![...doneNames].some(n => title.includes(n))) {
-        discovered.push({ id: p.replace(/[^a-zA-Z0-9_-]+/g, "-"), title, status: "complete" });
-      }
-    }
+    const treePaths = await listRepoTreePaths(owner, repo, branch, token);
+    const matchedPaths = config.code_globs.length
+      ? Array.from(new Set(micromatch(treePaths, config.code_globs, { dot: true }))).sort()
+      : [];
 
-    // 5) Commit artifacts
-    const wrote: string[] = [];
-    async function safePut(path: string, content: string, msg: string) {
-      try {
-        await putFile(owner, repo, path, content, branch, msg);
-        wrote.push(path);
-      } catch (e: any) {
-        wrote.push(`${path} (FAILED: ${e?.message || e})`);
+    const alreadyTracked = alreadyTrackedFactory(doneNames);
+    const discovered: BacklogItem[] = [];
+
+    for (const query of dbSuccesses) {
+      const title = `Database check present: ${query}`;
+      if (!alreadyTracked(title)) {
+        discovered.push({ id: slugify(`db-${query}`), title, status: "complete" });
       }
     }
 
-    const backlogBody = yamlList(discovered);
-    await safePut("docs/backlog-discovered.yml", backlogBody, "chore(roadmap): update backlog-discovered [skip ci]");
+    for (const path of matchedPaths) {
+      const title = `Code path matched: ${path}`;
+      if (!alreadyTracked(title)) {
+        discovered.push({ id: slugify(`code-${path}`), title, status: "complete" });
+      }
+    }
 
-    const summary = `Repo: ${owner}/${repo}
-Generated: ${new Date().toISOString()}
+    const backlogPath = projectAwarePath("docs/backlog-discovered.yml", projectKey);
+    await safePut(
+      owner,
+      repo,
+      branch,
+      backlogPath,
+      backlogYaml(discovered, discoverLabel),
+      projectKey
+        ? `chore(${projectKey}): update backlog-discovered [skip ci]`
+        : "chore(roadmap): update backlog-discovered [skip ci]",
+      wrote,
+      failures,
+      token,
+    );
 
-Newly discovered, already-done items (not on roadmap):
-${discovered.length ? discovered.map(d => `- ${d.title}`).join("\n") : "- none"}
-`;
-    await safePut("docs/summary.txt", summary, "chore(roadmap): update summary [skip ci]");
+    const summary = buildSummary({
+      owner,
+      repo,
+      branch,
+      project: projectKey || undefined,
+      config,
+      dbSuccesses,
+      dbFailures,
+      matchedPaths,
+      discovered,
+    });
 
-    return NextResponse.json({ ok: true, discovered: discovered.length, wrote }, { headers: { "cache-control": "no-store" } });
-  } catch (e: any) {
-    return NextResponse.json({ error: String(e?.message || e) }, { status: 500 });
+    const summaryPath = projectAwarePath("docs/summary.txt", projectKey);
+    await safePut(
+      owner,
+      repo,
+      branch,
+      summaryPath,
+      summary,
+      projectKey ? `chore(${projectKey}): update summary [skip ci]` : "chore(roadmap): update summary [skip ci]",
+      wrote,
+      failures,
+      token,
+    );
+
+    const ok = failures.length === 0;
+    if (!ok) {
+      config.notes.push(
+        ...failures.map(
+          (failure) => `GitHub write failed: ${failure}. Ensure the dashboard has push access to ${owner}/${repo}.`,
+        ),
+      );
+    }
+    const detail =
+      failures.length > 0
+        ? `Some files could not be written to GitHub. Check your token permissions and branch settings.\n${failures.join("\n")}`
+        : undefined;
+
+    return NextResponse.json(
+      {
+        ok,
+        discovered: discovered.length,
+        items: discovered,
+        wrote,
+        config,
+        db: dbResults,
+        code_matches: matchedPaths,
+        ...(detail ? { error: "GitHub writes failed", detail } : {}),
+      },
+      {
+        status: ok ? 200 : 207,
+        headers: { "cache-control": "no-store" },
+      },
+    );
+  } catch (error: any) {
+    return NextResponse.json({ error: String(error?.message || error) }, { status: 500 });
   }
+}
+
+export async function OPTIONS() {
+  return NextResponse.json({ ok: true }, { status: 200 });
+}
+
+export async function GET(req: NextRequest) {
+  const redirectUrl = new URL("/wizard/midproject/workspace#discover", req.url);
+  return NextResponse.redirect(redirectUrl, { status: 307 });
 }

--- a/app/api/gtm/[owner]/[repo]/route.ts
+++ b/app/api/gtm/[owner]/[repo]/route.ts
@@ -1,0 +1,134 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { getFileRaw, putFile } from "@/lib/github";
+import { describeProjectFile, normalizeProjectKey, projectAwarePath } from "@/lib/project-paths";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const GTM_TEMPLATE = [
+  "# Go-To-Market Plan",
+  "",
+  "## Market",
+  "- Target audience:",
+  "- Problem we solve:",
+  "- Key insights:",
+  "",
+  "## Positioning",
+  "- Value proposition:",
+  "- Differentiators:",
+  "- Competitive context:",
+  "",
+  "## Channels",
+  "- Primary:",
+  "- Secondary:",
+  "- Enablement needs:",
+  "",
+  "## Launch Timeline",
+  "- Week 0: Internal enablement",
+  "- Week 1: Beta/early access",
+  "- Week 2: Public launch",
+  "- Follow-up:",
+  "",
+  "## Pricing",
+  "- Model:",
+  "- Tiers:",
+  "- Promotions/incentives:",
+  "",
+  "## Metrics",
+  "- Activation:",
+  "- Engagement:",
+  "- Revenue:",
+  "- Retention:",
+  "",
+  "## Owners",
+  "- Product:",
+  "- Marketing:",
+  "- Sales/CS:",
+  "",
+  "## Next Steps",
+  "- [ ] Align stakeholders",
+  "- [ ] Publish launch checklist",
+  "- [ ] Instrument analytics dashboards",
+  "",
+].join("\n");
+
+type RouteParams = { params: { owner: string; repo: string } };
+
+type PlanResponse = { content: string };
+
+type CommitResponse = { ok: true; content: string; created: boolean };
+
+type CommitPayload = {
+  branch?: string;
+  content?: string;
+  project?: string;
+};
+
+function normalizeBranch(value: unknown) {
+  if (typeof value !== "string") return "main";
+  const trimmed = value.trim();
+  return trimmed ? trimmed : "main";
+}
+
+export async function GET(req: NextRequest, context: RouteParams) {
+  const { owner, repo } = context.params;
+  try {
+    const url = new URL(req.url);
+    const branch = url.searchParams.get("branch") || undefined;
+    const projectKey = normalizeProjectKey(url.searchParams.get("project"));
+    const token = req.headers.get("x-github-pat")?.trim() || undefined;
+    const path = projectAwarePath("docs/gtm-plan.md", projectKey);
+    const raw = await getFileRaw(owner, repo, path, branch, token);
+    if (raw === null) {
+      return NextResponse.json({ error: "not_found" }, { status: 404 });
+    }
+    const response: PlanResponse = { content: raw };
+    return NextResponse.json(response);
+  } catch (error: any) {
+    return NextResponse.json(
+      { error: error?.message ?? "Failed to load GTM plan" },
+      { status: 500 },
+    );
+  }
+}
+
+export async function POST(req: NextRequest, context: RouteParams) {
+  const { owner, repo } = context.params;
+  let payload: CommitPayload;
+  try {
+    payload = (await req.json()) as CommitPayload;
+  } catch {
+    payload = {};
+  }
+
+  const branch = normalizeBranch(payload?.branch);
+  const providedContent = typeof payload?.content === "string" ? payload.content : undefined;
+  const projectKey = normalizeProjectKey(payload?.project);
+
+  if (providedContent !== undefined && !providedContent.trim()) {
+    return NextResponse.json({ error: "GTM plan content cannot be empty" }, { status: 400 });
+  }
+
+  const finalContent = providedContent ?? GTM_TEMPLATE;
+
+  try {
+    const token = req.headers.get("x-github-pat")?.trim() || undefined;
+    const path = projectAwarePath("docs/gtm-plan.md", projectKey);
+    const existing = await getFileRaw(owner, repo, path, branch, token);
+    const label = describeProjectFile("docs/gtm-plan.md", projectKey);
+    const message = existing === null
+      ? `feat(gtm): add ${label}`
+      : `chore(gtm): update ${label}`;
+
+    await putFile(owner, repo, path, finalContent, branch, message, token);
+
+    const response: CommitResponse = { ok: true, content: finalContent, created: existing === null };
+    return NextResponse.json(response);
+  } catch (error: any) {
+    return NextResponse.json(
+      { error: error?.message ?? "Failed to save GTM plan" },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/roadmap/import/route.ts
+++ b/app/api/roadmap/import/route.ts
@@ -1,0 +1,199 @@
+import { NextResponse } from "next/server";
+import { load } from "js-yaml";
+
+import { getFileRaw, putFile } from "@/lib/github";
+import { describeProjectFile, normalizeProjectKey, projectAwarePath } from "@/lib/project-paths";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const INFRA_FACTS_TEMPLATE = [
+  "# Infrastructure facts",
+  "",
+  "- **Primary environment**: ",
+  "- **Database**: ",
+  "- **Deployment pipeline**: ",
+  "- **Monitoring & alerts**: ",
+  "",
+  "Add infra constraints, compliance requirements, and escalation paths so the build team ships with confidence.",
+  "",
+].join("\n");
+
+const TECH_STACK_TEMPLATE = [
+  "version: 1",
+  "stack:",
+  "  frontend:",
+  "    frameworks: []",
+  "    libraries: []",
+  "  backend:",
+  "    languages: []",
+  "    services: []",
+  "  infrastructure:",
+  "    platforms: []",
+  "    observability: []",
+  "integrations: []",
+  "notes: []",
+  "",
+].join("\n");
+
+const ROADMAP_WORKFLOW_TEMPLATE = [
+  "name: Roadmap checks",
+  "on:",
+  "  push:",
+  "    branches: [main]",
+  "  pull_request:",
+  "jobs:",
+  "  roadmap:",
+  "    runs-on: ubuntu-latest",
+  "    steps:",
+  "      - uses: actions/checkout@v4",
+  "      - uses: actions/setup-node@v4",
+  "        with:",
+  "          node-version: 20",
+  "      - run: npm ci",
+  "      - run: npm run roadmap:check",
+  "        env:",
+  "          READ_ONLY_CHECKS_URL: ${{ secrets.READ_ONLY_CHECKS_URL }}",
+  "",
+].join("\n");
+
+type ImportRequestBody = {
+  owner?: string;
+  repo?: string;
+  branch?: string;
+  roadmap?: string;
+  project?: string;
+};
+
+type ImportSuccess = {
+  ok: true;
+  created: string[];
+  skipped: string[];
+  branch?: string;
+  prUrl?: string;
+  pullRequestNumber?: number;
+};
+
+type ImportError = {
+  error: string;
+  detail?: string;
+  prUrl?: string;
+};
+
+export async function POST(req: Request) {
+  let body: ImportRequestBody;
+  try {
+    body = (await req.json()) as ImportRequestBody;
+  } catch (error) {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const url = new URL(req.url);
+  const asPR = url.searchParams.get("asPR") === "true";
+  const owner = typeof body?.owner === "string" ? body.owner.trim() : "";
+  const repo = typeof body?.repo === "string" ? body.repo.trim() : "";
+  const branch = typeof body?.branch === "string" && body.branch.trim() ? body.branch.trim() : "main";
+  const roadmap = typeof body?.roadmap === "string" ? body.roadmap : "";
+  const projectKey = normalizeProjectKey(body?.project);
+  const token = req.headers.get("x-github-pat")?.trim() || undefined;
+
+  if (!owner || !repo) {
+    return NextResponse.json({ error: "owner and repo are required" }, { status: 400 });
+  }
+
+  if (!roadmap.trim()) {
+    return NextResponse.json({ error: "Roadmap file is empty" }, { status: 400 });
+  }
+
+  try {
+    const parsed = load(roadmap);
+    if (!parsed || typeof parsed !== "object") {
+      return NextResponse.json({ error: "docs/roadmap.yml must parse into an object" }, { status: 400 });
+    }
+  } catch (error: any) {
+    return NextResponse.json(
+      { error: "Failed to parse roadmap.yml", detail: error?.message ?? String(error) },
+      { status: 400 },
+    );
+  }
+
+  const created: string[] = [];
+  const skipped: string[] = [];
+
+  try {
+    const targetPath = projectAwarePath("docs/roadmap.yml", projectKey);
+    const message = projectKey
+      ? `feat(${projectKey}): import roadmap definition`
+      : "feat(roadmap): import roadmap definition";
+    const result = await putFile(
+      owner,
+      repo,
+      targetPath,
+      roadmap,
+      branch,
+      message,
+      token,
+      asPR
+        ? {
+            asPR: true,
+            prTitle: message,
+            prBody: "Seeded via Roadmap Ready workspace.",
+          }
+        : undefined,
+    );
+    created.push(targetPath);
+
+    const workingBranch = asPR ? result.branch : branch;
+
+    const scaffoldTargets = [
+      {
+        path: projectAwarePath("docs/infra-facts.md", projectKey),
+        content: INFRA_FACTS_TEMPLATE,
+        message: projectKey
+          ? `chore(${projectKey}): scaffold ${describeProjectFile("docs/infra-facts.md", projectKey)}`
+          : "chore(roadmap): scaffold docs/infra-facts.md",
+      },
+      {
+        path: projectAwarePath("docs/tech-stack.yml", projectKey),
+        content: TECH_STACK_TEMPLATE,
+        message: projectKey
+          ? `chore(${projectKey}): scaffold ${describeProjectFile("docs/tech-stack.yml", projectKey)}`
+          : "chore(roadmap): scaffold docs/tech-stack.yml",
+      },
+      {
+        path: projectAwarePath(".github/workflows/roadmap.yml", projectKey),
+        content: ROADMAP_WORKFLOW_TEMPLATE,
+        message: projectKey
+          ? `chore(${projectKey}): add roadmap workflow`
+          : "chore(roadmap): add roadmap workflow",
+      },
+    ] as const;
+
+    for (const target of scaffoldTargets) {
+      const existing = await getFileRaw(owner, repo, target.path, workingBranch, token);
+
+      if (existing !== null) {
+        skipped.push(target.path);
+        continue;
+      }
+
+      await putFile(owner, repo, target.path, target.content, workingBranch, target.message, token);
+      created.push(target.path);
+    }
+
+    const response: ImportSuccess = {
+      ok: true,
+      created,
+      skipped,
+      branch: workingBranch,
+      prUrl: result.pullRequest?.html_url ?? result.pullRequest?.url,
+      pullRequestNumber: result.pullRequest?.number,
+    };
+    return NextResponse.json(response);
+  } catch (error: any) {
+    const payload: ImportError = {
+      error: error?.message ?? "Failed to import roadmap",
+    };
+    return NextResponse.json(payload, { status: 500 });
+  }
+}

--- a/app/api/settings/save/route.ts
+++ b/app/api/settings/save/route.ts
@@ -1,0 +1,84 @@
+import { NextRequest, NextResponse } from "next/server";
+
+function isOptionalString(value: unknown) {
+  return typeof value === "undefined" || typeof value === "string";
+}
+
+function hasText(value: unknown) {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json();
+    if (!body || typeof body !== "object") {
+      return NextResponse.json({ error: "invalid payload" }, { status: 400 });
+    }
+
+    const { defaults, repos } = body as {
+      defaults?: Record<string, unknown>;
+      repos?: Array<Record<string, unknown>>;
+    };
+
+    if (defaults && typeof defaults !== "object") {
+      return NextResponse.json({ error: "invalid defaults" }, { status: 400 });
+    }
+
+    if (defaults) {
+      for (const key of Object.keys(defaults)) {
+        if (!isOptionalString((defaults as Record<string, unknown>)[key])) {
+          return NextResponse.json({ error: "defaults must be strings" }, { status: 400 });
+        }
+      }
+    }
+
+    if (repos && !Array.isArray(repos)) {
+      return NextResponse.json({ error: "invalid repos" }, { status: 400 });
+    }
+
+    if (Array.isArray(repos)) {
+      for (const repo of repos) {
+        if (!hasText(repo?.owner) || !hasText(repo?.repo)) {
+          return NextResponse.json({ error: "repo must include owner and repo" }, { status: 400 });
+        }
+        if (!isOptionalString(repo?.displayName)) {
+          return NextResponse.json({ error: "invalid displayName" }, { status: 400 });
+        }
+        if (!isOptionalString(repo?.supabaseReadOnlyUrl)) {
+          return NextResponse.json({ error: "invalid supabase url" }, { status: 400 });
+        }
+        if (!isOptionalString(repo?.githubPat) || !isOptionalString(repo?.openaiKey)) {
+          return NextResponse.json({ error: "invalid repo secrets" }, { status: 400 });
+        }
+
+        if (repo?.projects && !Array.isArray(repo.projects)) {
+          return NextResponse.json({ error: "invalid projects" }, { status: 400 });
+        }
+
+        if (Array.isArray(repo?.projects)) {
+          for (const project of repo.projects as Array<Record<string, unknown>>) {
+            if (!hasText(project?.name ?? project?.id)) {
+              return NextResponse.json({ error: "project name required" }, { status: 400 });
+            }
+            if (!isOptionalString(project?.id)) {
+              return NextResponse.json({ error: "invalid project id" }, { status: 400 });
+            }
+            if (
+              !isOptionalString(project?.supabaseReadOnlyUrl) ||
+              !isOptionalString(project?.githubPat) ||
+              !isOptionalString(project?.openaiKey)
+            ) {
+              return NextResponse.json({ error: "invalid project secrets" }, { status: 400 });
+            }
+          }
+        }
+      }
+    }
+
+    // Placeholder: persistence will be implemented with secure storage.
+    // For now, the client stores secrets in localStorage.
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    return NextResponse.json({ error: "unable to parse request" }, { status: 400 });
+  }
+}

--- a/app/api/status/[owner]/[repo]/route.ts
+++ b/app/api/status/[owner]/[repo]/route.ts
@@ -1,10 +1,26 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getFileRaw } from "@/lib/github";
-export async function GET(_req:NextRequest, { params }:{ params:{ owner:string; repo:string }}) {
+import { projectAwarePath, normalizeProjectKey } from "@/lib/project-paths";
+
+export async function GET(req: NextRequest, { params }: { params: { owner: string; repo: string } }) {
   try {
-    const raw = await getFileRaw(params.owner, params.repo, "docs/roadmap-status.json").catch(()=>null);
+    const url = new URL(req.url);
+    const branch = url.searchParams.get("branch") || undefined;
+    const projectKey = normalizeProjectKey(url.searchParams.get("project"));
+    const token = req.headers.get("x-github-pat")?.trim() || undefined;
+    const raw = await getFileRaw(
+      params.owner,
+      params.repo,
+      projectAwarePath("docs/roadmap-status.json", projectKey),
+      branch,
+      token,
+    ).catch(() => null);
     if (!raw) return NextResponse.json({ error:"not_found" }, { status:404 });
-    return NextResponse.json(JSON.parse(raw));
+    const parsed = JSON.parse(raw);
+    if (projectKey) {
+      parsed.project = parsed.project ?? projectKey;
+    }
+    return NextResponse.json(parsed);
   } catch (e:any) {
     return NextResponse.json({ error: String(e?.message || e) }, { status:500 });
   }

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,0 +1,1 @@
+export { default } from "../page";

--- a/app/globals.css
+++ b/app/globals.css
@@ -217,6 +217,9 @@ button.ghost-button.danger{ border-color:rgba(248,113,113,0.45); color:rgba(248,
 button.ghost-button.danger:hover{ background:rgba(127,29,29,0.35); color:#fecdd3; border-color:rgba(248,113,113,0.7) }
 button.ghost-button.compact{ padding:6px 10px; font-size:12px }
 button.ghost-button:disabled{ opacity:0.6; cursor:not-allowed; background:transparent }
+button.primary-button{ background:rgba(78,161,255,0.22); border:1px solid rgba(78,161,255,0.6); color:var(--fg); font-weight:600; padding:8px 16px; border-radius:12px; cursor:pointer; transition:background 0.2s ease, border-color 0.2s ease, color 0.2s ease }
+button.primary-button:hover{ background:rgba(78,161,255,0.35); border-color:rgba(78,161,255,0.85) }
+button.primary-button:disabled{ opacity:0.55; cursor:not-allowed; background:rgba(78,161,255,0.12); border-color:rgba(78,161,255,0.35); color:var(--muted) }
 .item-title-row{ display:flex; align-items:center; gap:8px }
 .manual-pill{ display:inline-flex; align-items:center; padding:2px 8px; border-radius:999px; border:1px solid rgba(78,161,255,0.45); background:rgba(78,161,255,0.12); color:var(--accent); font-size:11px; letter-spacing:0.04em; text-transform:uppercase }
 .item-actions{ display:flex; align-items:center; gap:8px }
@@ -237,6 +240,16 @@ button.ghost-button:disabled{ opacity:0.6; cursor:not-allowed; background:transp
 .manual-error{ color:var(--danger); font-size:12px }
 .manual-hint{ font-size:12px; color:var(--muted); margin-top:8px }
 .manual-project-banner{ display:flex; align-items:center; justify-content:space-between; gap:12px }
+.gtm-plan-card{ display:grid; gap:16px }
+.gtm-plan-header{ display:grid; gap:6px }
+.gtm-plan-branch-form{ display:grid; gap:8px; max-width:320px }
+.gtm-plan-branch-controls{ display:flex; flex-wrap:wrap; gap:8px; align-items:center }
+.gtm-plan-empty{ border:1px dashed rgba(148,163,184,0.45); background:rgba(11,17,25,0.7); border-radius:14px; padding:16px; display:grid; gap:12px; color:var(--muted); font-size:14px }
+.gtm-plan-actions{ display:flex; flex-wrap:wrap; gap:10px; align-items:center }
+.gtm-plan-editor{ display:grid; gap:12px }
+.gtm-plan-editor textarea{ min-height:280px }
+.gtm-plan-error{ color:#fecdd3; font-size:13px }
+.gtm-plan-success{ color:var(--success); font-size:13px }
 .banner-title{ font-size:15px; font-weight:600; color:var(--fg) }
 .banner-subtitle{ font-size:13px; color:var(--muted) }
 .add-project-card{ display:grid; gap:18px }
@@ -246,6 +259,101 @@ button.ghost-button:disabled{ opacity:0.6; cursor:not-allowed; background:transp
 .add-project-actions .project-wizard{ font-size:14px }
 .add-project-hints{ margin:0; padding-left:18px; display:grid; gap:6px; font-size:13px; color:var(--muted) }
 .add-project-hints code{ font-size:12px }
+.add-project-wizard{ display:grid; gap:12px }
+.add-project-wizard h3{ margin:0; font-size:16px; color:#cfe2f3 }
+.add-project-wizard p{ margin:0; font-size:14px; line-height:1.5; color:var(--muted) }
+.add-project-wizard-grid{ display:grid; gap:12px; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)) }
+.add-project-wizard-card{ display:grid; gap:12px; padding:16px; border-radius:14px; border:1px solid #1f2732; background:rgba(12,18,28,0.85); transition:border-color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease; color:inherit; cursor:pointer; outline:none }
+.add-project-wizard-card:hover{ border-color:rgba(78,161,255,0.55); transform:translateY(-2px); box-shadow:0 12px 26px rgba(10,15,24,0.45) }
+.add-project-wizard-card:focus-visible{ border-color:rgba(148,205,255,0.85); box-shadow:0 0 0 3px rgba(78,161,255,0.3) }
+.add-project-wizard-card h4{ margin:0; font-size:16px; color:var(--fg) }
+.add-project-wizard-card p{ margin:0; font-size:14px; line-height:1.55; color:var(--muted) }
+.add-project-wizard-card ul{ margin:0; padding-left:18px; display:grid; gap:6px; font-size:13px; color:var(--muted) }
+.add-project-wizard-copy{ display:grid; gap:6px }
+.add-project-wizard-meta{ display:flex; align-items:center; gap:8px; font-size:12px; text-transform:uppercase; letter-spacing:0.08em; color:var(--muted) }
+.add-project-wizard-label{ display:inline-flex; align-items:center; justify-content:center; padding:4px 10px; border-radius:999px; border:1px solid #283042; background:rgba(15,21,32,0.75); color:var(--fg); font-size:11px; font-weight:600 }
+.add-project-wizard-sub{ font-size:11px; color:var(--muted) }
+.add-project-wizard-actions{ display:flex; flex-wrap:wrap; gap:8px }
+.add-project-wizard-action{ display:inline-flex; align-items:center; gap:6px; padding:6px 12px; border-radius:999px; border:1px solid #273244; background:rgba(18,26,38,0.95); color:var(--fg); font-size:13px; font-weight:600; text-decoration:none; transition:background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease }
+.add-project-wizard-action:hover{ border-color:rgba(78,161,255,0.45); color:#e6f0ff }
+.add-project-wizard-action--primary{ background:rgba(219,234,254,0.9); color:#0f172a; border-color:rgba(219,234,254,0.9) }
+.add-project-wizard-action--primary:hover{ background:#e8f1ff; color:#0b1220; border-color:#e8f1ff }
+.add-project-wizard-note{ margin:0; font-size:12px; line-height:1.5; color:rgba(167,197,255,0.85) }
 
 @media (min-width:560px){ .project-form-row{ grid-template-columns:repeat(2,minmax(0,1fr)) } }
 @media (max-width:980px){ .dashboard-shell{ grid-template-columns:1fr } .project-panel{ position:relative; top:auto; max-height:none; overflow:visible } .project-panel-body{ width:100%; margin-right:0; padding-right:0; overflow:visible } }
+
+/* Minimal Tailwind-inspired utilities for the wizard UI */
+.tw-space-y-10 > * + * { margin-top: 2.5rem; }
+.tw-space-y-3 > * + * { margin-top: 0.75rem; }
+.tw-space-y-2 > * + * { margin-top: 0.5rem; }
+.tw-inline-flex { display: inline-flex; }
+.tw-flex { display: flex; }
+.tw-grid { display: grid; }
+.tw-flex-col { flex-direction: column; }
+.tw-flex-wrap { flex-wrap: wrap; }
+.tw-items-center { align-items: center; }
+.tw-items-start { align-items: flex-start; }
+.tw-justify-center { justify-content: center; }
+.tw-gap-2 { gap: 0.5rem; }
+.tw-gap-3 { gap: 0.75rem; }
+.tw-gap-4 { gap: 1rem; }
+.tw-gap-6 { gap: 1.5rem; }
+.tw-gap-10 { gap: 2.5rem; }
+.tw-rounded-full { border-radius: 9999px; }
+.tw-rounded-3xl { border-radius: 1.5rem; }
+.tw-border { border: 1px solid rgba(148, 163, 184, 0.25); }
+.tw-border-slate-800 { border-color: rgba(30, 41, 59, 0.75); }
+.tw-px-3 { padding-left: 0.75rem; padding-right: 0.75rem; }
+.tw-py-1 { padding-top: 0.25rem; padding-bottom: 0.25rem; }
+.tw-p-6 { padding: 1.5rem; }
+.tw-p-8 { padding: 2rem; }
+.tw-text-xs { font-size: 0.75rem; line-height: 1rem; }
+.tw-text-sm { font-size: 0.875rem; line-height: 1.5rem; }
+.tw-text-lg { font-size: 1.125rem; line-height: 1.75rem; }
+.tw-text-xl { font-size: 1.25rem; line-height: 1.75rem; }
+.tw-text-2xl { font-size: 1.5rem; line-height: 2rem; }
+.tw-text-3xl { font-size: 1.875rem; line-height: 2.25rem; }
+.tw-text-\[0\.7rem\] { font-size: 0.7rem; line-height: 1rem; }
+.tw-font-medium { font-weight: 500; }
+.tw-font-semibold { font-weight: 600; }
+.tw-font-bold { font-weight: 700; }
+.tw-uppercase { text-transform: uppercase; }
+.tw-tracking-wide { letter-spacing: 0.12em; }
+.tw-text-slate-100 { color: #e2e8f0; }
+.tw-text-slate-300 { color: #94a3b8; }
+.tw-text-slate-400 { color: #7c8a9f; }
+.tw-leading-tight { line-height: 1.2; }
+.tw-leading-snug { line-height: 1.35; }
+.tw-leading-relaxed { line-height: 1.6; }
+.tw-h-full { height: 100%; }
+.tw-bg-slate-900 { background-color: rgba(15, 23, 42, 0.85); }
+.tw-transition { transition-property: all; }
+.tw-duration-200 { transition-duration: 200ms; }
+.tw-ease-out { transition-timing-function: cubic-bezier(0, 0, 0.2, 1); }
+.tw-transform { transform: translateZ(0); }
+.tw-list-disc { list-style: disc; }
+.tw-pl-5 { padding-left: 1.25rem; }
+.tw-block { display: block; }
+.tw-mb-6 { margin-bottom: 1.5rem; }
+
+.hover\:tw-border-slate-700:hover { border-color: rgba(51, 65, 85, 0.8); }
+.hover\:tw-shadow-xl:hover { box-shadow: 0 24px 60px rgba(8, 15, 30, 0.45); }
+.hover\:tw-translate-y-\[-4px\]:hover { transform: translateY(-4px); }
+.hover\:tw-text-slate-100:hover { color: #e2e8f0; }
+
+.md\:tw-grid-cols-2 { grid-template-columns: repeat(1, minmax(0, 1fr)); }
+@media (min-width: 768px) {
+  .md\:tw-grid-cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+}
+
+.code-editor{ position:relative; border-radius:18px; border:1px solid rgba(51,65,85,0.55); background:rgba(8,12,18,0.85); overflow:hidden; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace; }
+.code-editor__preview{ margin:0; padding:18px; white-space:pre; overflow:auto; max-height:420px; color:#e7eef7; pointer-events:none; }
+.code-editor__textarea{ position:absolute; inset:0; resize:none; padding:18px; border:none; background:transparent; color:transparent; caret-color:#f8fafc; font: inherit; line-height:1.5; tab-size:2; outline:none; overflow:auto; }
+.code-editor__textarea::selection{ background:rgba(148,163,184,0.25); }
+.token-key{ color:#93c5fd; font-weight:600; }
+.token-colon{ color:#7dd3fc; }
+.token-string{ color:#fcd34d; }
+.token-comment{ color:#94a3b8; font-style:italic; }
+.token-dash{ color:#f472b6; }
+

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,9 +1,10 @@
-import './globals.css';
-import React from 'react';
+import "./globals.css";
+import Link from "next/link";
+import React from "react";
 
 export const metadata = {
-  title: 'Roadmap Dashboard Pro',
-  description: 'Continuous context dashboard for roadmap-kit projects (GitHub App ready)'
+  title: "Roadmap Dashboard Pro",
+  description: "Continuous context dashboard for roadmap-kit projects (GitHub App ready)",
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
@@ -11,9 +12,34 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     <html lang="en">
       <body>
         <div className="container">
-          <h1>🚀 Roadmap Dashboard Pro</h1>
-          <div className="hint">Onboard repos, view status, edit rc, and verify infra — safely.</div>
-          <div style={{height:10}} />
+          <header className="tw-flex tw-flex-col tw-gap-4 tw-mb-6">
+            <div className="tw-flex tw-flex-wrap tw-items-start tw-justify-between tw-gap-4">
+              <div className="tw-space-y-2">
+                <h1>🚀 Roadmap Dashboard Pro</h1>
+                <div className="hint">Onboard repos, view status, edit rc, and verify infra — safely.</div>
+              </div>
+              <nav className="tw-flex tw-w-full tw-flex-wrap tw-gap-2 tw-pt-1 tw-text-sm sm:tw-w-auto sm:tw-justify-end">
+                <Link
+                  href="/"
+                  className="tw-inline-flex tw-items-center tw-gap-2 tw-rounded-full tw-border tw-border-slate-800 tw-px-3 tw-py-1 tw-font-medium tw-text-slate-300 tw-transition tw-duration-200 tw-ease-out hover:tw-border-slate-700 hover:tw-text-slate-100"
+                >
+                  <span>Dashboard</span>
+                </Link>
+                <Link
+                  href="/wizard"
+                  className="tw-inline-flex tw-items-center tw-gap-2 tw-rounded-full tw-border tw-border-slate-800 tw-px-3 tw-py-1 tw-font-medium tw-text-slate-300 tw-transition tw-duration-200 tw-ease-out hover:tw-border-slate-700 hover:tw-text-slate-100"
+                >
+                  <span>Add New Project</span>
+                </Link>
+                <Link
+                  href="/settings"
+                  className="tw-inline-flex tw-items-center tw-gap-2 tw-rounded-full tw-border tw-border-slate-800 tw-px-3 tw-py-1 tw-font-medium tw-text-slate-300 tw-transition tw-duration-200 tw-ease-out hover:tw-border-slate-700 hover:tw-text-slate-100"
+                >
+                  <span>Settings</span>
+                </Link>
+              </nav>
+            </div>
+          </header>
           {children}
         </div>
       </body>

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,0 +1,620 @@
+"use client";
+
+import { ChangeEvent, FormEvent, useEffect, useMemo, useState } from "react";
+
+import {
+  createProjectEntry,
+  createRepoEntry,
+  normalizeSecretsForSave,
+  readLocalSecrets,
+  type RepoProjectSecrets,
+  type RepoSecrets,
+  type SecretsStore,
+  resolveSecrets,
+  useLocalSecrets,
+  writeSecretsToStorage,
+} from "@/lib/use-local-secrets";
+
+const EMPTY_STORE: SecretsStore = { defaults: {}, repos: [] };
+
+type RepoFormState = {
+  owner: string;
+  repo: string;
+  displayName: string;
+};
+
+type ProjectFormState = {
+  name: string;
+};
+
+export default function SettingsPage() {
+  const [store, setStore] = useState<SecretsStore>(EMPTY_STORE);
+  const [initialSerialized, setInitialSerialized] = useState<string>("{}");
+  const [selectedRepoId, setSelectedRepoId] = useState<string | null>(null);
+  const [selectedProjectId, setSelectedProjectId] = useState<string | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+  const [lastSaved, setLastSaved] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [repoError, setRepoError] = useState<string | null>(null);
+  const [projectError, setProjectError] = useState<string | null>(null);
+  const [repoForm, setRepoForm] = useState<RepoFormState>({ owner: "", repo: "", displayName: "" });
+  const [projectForm, setProjectForm] = useState<ProjectFormState>({ name: "" });
+
+  const liveStore = useLocalSecrets();
+
+  useEffect(() => {
+    try {
+      const loaded = normalizeSecretsForSave(readLocalSecrets());
+      setStore(loaded);
+      const serialized = JSON.stringify(loaded);
+      setInitialSerialized(serialized);
+      if (loaded.repos.length) {
+        setSelectedRepoId(loaded.repos[0].id);
+        if (loaded.repos[0].projects.length) {
+          setSelectedProjectId(loaded.repos[0].projects[0].id);
+        }
+      }
+    } catch (err) {
+      console.error("Failed to load stored secrets", err);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (selectedRepoId && !store.repos.some((repo) => repo.id === selectedRepoId)) {
+      const fallback = store.repos[0]?.id ?? null;
+      setSelectedRepoId(fallback);
+      const fallbackRepo = fallback ? store.repos.find((repo) => repo.id === fallback) ?? null : null;
+      setSelectedProjectId(fallbackRepo?.projects[0]?.id ?? null);
+    }
+  }, [selectedRepoId, store.repos]);
+
+  useEffect(() => {
+    if (!selectedRepoId) {
+      setSelectedProjectId(null);
+      return;
+    }
+    const repo = store.repos.find((entry) => entry.id === selectedRepoId);
+    if (!repo) {
+      setSelectedProjectId(null);
+      return;
+    }
+    if (selectedProjectId && !repo.projects.some((project) => project.id === selectedProjectId)) {
+      setSelectedProjectId(repo.projects[0]?.id ?? null);
+    }
+  }, [selectedRepoId, selectedProjectId, store.repos]);
+
+  const selectedRepo = useMemo(
+    () => store.repos.find((repo) => repo.id === selectedRepoId) ?? null,
+    [store.repos, selectedRepoId],
+  );
+
+  const selectedProject = useMemo(
+    () => selectedRepo?.projects.find((project) => project.id === selectedProjectId) ?? null,
+    [selectedRepo, selectedProjectId],
+  );
+
+  const normalizedForComparison = useMemo(() => JSON.stringify(normalizeSecretsForSave(store)), [store]);
+  const hasChanges = normalizedForComparison !== initialSerialized;
+
+  useEffect(() => {
+    const normalizedLive = normalizeSecretsForSave(liveStore);
+    const serializedLive = JSON.stringify(normalizedLive);
+    if (!hasChanges && serializedLive !== initialSerialized) {
+      setStore(normalizedLive);
+      setInitialSerialized(serializedLive);
+      if (!selectedRepoId && normalizedLive.repos.length) {
+        setSelectedRepoId(normalizedLive.repos[0].id);
+        setSelectedProjectId(normalizedLive.repos[0].projects[0]?.id ?? null);
+      }
+    }
+  }, [hasChanges, initialSerialized, liveStore, selectedRepoId]);
+
+  const defaultGithub = Boolean(store.defaults.githubPat && store.defaults.githubPat.trim());
+  const defaultOpenAi = Boolean(store.defaults.openaiKey && store.defaults.openaiKey.trim());
+
+  const repoResolved = selectedRepo
+    ? resolveSecrets(store, selectedRepo.owner, selectedRepo.repo, selectedProject?.id)
+    : null;
+  const supabaseSourceLabel = repoResolved?.sources.supabaseReadOnlyUrl
+    ? repoResolved.sources.supabaseReadOnlyUrl === "project"
+      ? "project override"
+      : repoResolved.sources.supabaseReadOnlyUrl === "repo"
+      ? "repo default"
+      : "global default"
+    : null;
+
+  const handleRepoFormChange = (field: keyof RepoFormState) => (event: ChangeEvent<HTMLInputElement>) => {
+    setRepoForm((prev) => ({ ...prev, [field]: event.target.value }));
+  };
+
+  const handleProjectFormChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setProjectForm({ name: event.target.value });
+  };
+
+  const addRepository = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setRepoError(null);
+    const owner = repoForm.owner.trim();
+    const repoName = repoForm.repo.trim();
+    const displayName = repoForm.displayName.trim();
+    if (!owner || !repoName) {
+      setRepoError("Enter both owner and repository name.");
+      return;
+    }
+    const duplicate = store.repos.some(
+      (repo) => repo.owner.trim().toLowerCase() === owner.toLowerCase() && repo.repo.trim().toLowerCase() === repoName.toLowerCase(),
+    );
+    if (duplicate) {
+      setRepoError("Repository already linked.");
+      return;
+    }
+    const entry = createRepoEntry(owner, repoName, displayName);
+    setStore((prev) => ({ ...prev, repos: [...prev.repos, entry] }));
+    setSelectedRepoId(entry.id);
+    setSelectedProjectId(entry.projects[0]?.id ?? null);
+    setRepoForm({ owner: "", repo: "", displayName: "" });
+  };
+
+  const removeRepository = (id: string) => {
+    setStore((prev) => ({ ...prev, repos: prev.repos.filter((repo) => repo.id !== id) }));
+    if (selectedRepoId === id) {
+      setSelectedRepoId(null);
+      setSelectedProjectId(null);
+    }
+  };
+
+  const updateSelectedRepo = (updater: (repo: RepoSecrets) => RepoSecrets) => {
+    if (!selectedRepo) return;
+    setStore((prev) => ({
+      ...prev,
+      repos: prev.repos.map((repo) => {
+        if (repo.id !== selectedRepo.id) return repo;
+        const clone: RepoSecrets = {
+          ...repo,
+          projects: repo.projects.map((project) => ({ ...project })),
+        };
+        const updated = updater(clone);
+        return {
+          ...updated,
+          projects: updated.projects.map((project) => ({ ...project })),
+        };
+      }),
+    }));
+  };
+
+  const updateSelectedProject = (updater: (project: RepoProjectSecrets) => RepoProjectSecrets) => {
+    if (!selectedRepo || !selectedProject) return;
+    updateSelectedRepo((repo) => ({
+      ...repo,
+      projects: repo.projects.map((project) => (project.id === selectedProject.id ? updater({ ...project }) : project)),
+    }));
+  };
+
+  const onRepoFieldChange = (field: "displayName" | "supabaseReadOnlyUrl" | "githubPat" | "openaiKey") =>
+    (event: ChangeEvent<HTMLInputElement>) => {
+      const value = event.target.value;
+      updateSelectedRepo((repo) => ({ ...repo, [field]: value }));
+    };
+
+  const onProjectFieldChange = (field: "name" | "supabaseReadOnlyUrl" | "githubPat" | "openaiKey") =>
+    (event: ChangeEvent<HTMLInputElement>) => {
+      const value = event.target.value;
+      updateSelectedProject((project) => ({ ...project, [field]: value }));
+      if (field === "name") {
+        setSelectedProjectId((prev) => prev);
+      }
+    };
+
+  const addProject = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setProjectError(null);
+    if (!selectedRepo) {
+      setProjectError("Select a repository first.");
+      return;
+    }
+    const name = projectForm.name.trim();
+    if (!name) {
+      setProjectError("Name your project before adding it.");
+      return;
+    }
+    const existing = selectedRepo.projects.some((project) => project.name.toLowerCase() === name.toLowerCase());
+    if (existing) {
+      setProjectError("Project already exists for this repository.");
+      return;
+    }
+    const entry = createProjectEntry(name);
+    updateSelectedRepo((repo) => ({ ...repo, projects: [...repo.projects, entry] }));
+    setSelectedProjectId(entry.id);
+    setProjectForm({ name: "" });
+  };
+
+  const removeProject = (id: string) => {
+    if (!selectedRepo) return;
+    const remaining = selectedRepo.projects.filter((project) => project.id !== id);
+    updateSelectedRepo((repo) => ({ ...repo, projects: repo.projects.filter((project) => project.id !== id) }));
+    if (selectedProjectId === id) {
+      setSelectedProjectId(remaining[0]?.id ?? null);
+    }
+  };
+
+  const handleSave = async () => {
+    setIsSaving(true);
+    setError(null);
+    try {
+      const normalized = normalizeSecretsForSave(store);
+      const response = await fetch("/api/settings/save", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(normalized),
+      });
+      if (!response.ok) {
+        const data = await response.json().catch(() => ({}));
+        throw new Error((data as { error?: string })?.error || "Failed to save settings");
+      }
+      writeSecretsToStorage(normalized);
+      setStore(normalized);
+      const serialized = JSON.stringify(normalized);
+      setInitialSerialized(serialized);
+      setLastSaved(new Date().toISOString());
+    } catch (err) {
+      console.error(err);
+      setError(err instanceof Error ? err.message : "Unable to save settings");
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <div className="mx-auto flex w-full max-w-6xl flex-col gap-10 px-6 py-10">
+      <div className="space-y-3">
+        <h1 className="text-3xl font-semibold text-slate-900">Secrets &amp; integrations</h1>
+        <p className="max-w-3xl text-sm text-slate-600">
+          Manage default API keys, connect repositories, and configure per-project Supabase probes. Credentials are stored in
+          your browser for now and never leave your device.
+        </p>
+        <div className="rounded-md border border-slate-200 bg-slate-50 px-4 py-3 text-xs text-slate-600">
+          <p className="font-medium text-slate-700">Heads up</p>
+          <p>
+            Values saved here are written to <code>localStorage</code>. Clearing your browser data removes them. Re-enter
+            credentials on each device you use.
+          </p>
+        </div>
+      </div>
+
+      <section className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+        <header className="space-y-1">
+          <h2 className="text-xl font-medium text-slate-900">Global defaults</h2>
+          <p className="text-sm text-slate-600">GitHub and OpenAI keys apply to every project unless you override them below.</p>
+        </header>
+        <div className="mt-6 grid gap-6 md:grid-cols-2">
+          <label className="flex flex-col gap-2 text-sm font-medium text-slate-700">
+            GitHub personal access token
+            <input
+              type="password"
+              value={store.defaults.githubPat ?? ""}
+              onChange={(event) =>
+                setStore((prev) => ({
+                  ...prev,
+                  defaults: { ...prev.defaults, githubPat: event.target.value },
+                }))
+              }
+              className="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-200"
+              placeholder="ghp_xxxxxxxxxxxxxxxxxxxxx"
+            />
+            <span className="text-xs font-normal text-slate-500">
+              {defaultGithub ? "Default GitHub token detected." : "Required for committing roadmap artifacts."}
+            </span>
+          </label>
+          <label className="flex flex-col gap-2 text-sm font-medium text-slate-700">
+            OpenAI API key
+            <input
+              type="password"
+              value={store.defaults.openaiKey ?? ""}
+              onChange={(event) =>
+                setStore((prev) => ({
+                  ...prev,
+                  defaults: { ...prev.defaults, openaiKey: event.target.value },
+                }))
+              }
+              className="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-200"
+              placeholder="sk-..."
+            />
+            <span className="text-xs font-normal text-slate-500">
+              {defaultOpenAi ? "Default OpenAI key detected." : "Add to enable brainstorming and roadmap generation."}
+            </span>
+          </label>
+        </div>
+      </section>
+
+      <section className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+        <div className="grid gap-8 lg:grid-cols-[260px,1fr]">
+          <aside className="space-y-6">
+            <div className="space-y-2">
+              <h2 className="text-base font-semibold text-slate-900">Linked repositories</h2>
+              <p className="text-xs text-slate-500">
+                Add every repo you want the wizard to manage. Each repo can host multiple projects with their own Supabase
+                probes and overrides.
+              </p>
+            </div>
+            <div className="space-y-2">
+              {store.repos.length ? (
+                <ul className="space-y-2">
+                  {store.repos.map((repo) => {
+                    const isActive = repo.id === selectedRepoId;
+                    const label = repo.displayName?.trim() || `${repo.owner}/${repo.repo}`;
+                    return (
+                      <li key={repo.id} className="flex items-center gap-2">
+                        <button
+                          type="button"
+                          onClick={() => {
+                            setSelectedRepoId(repo.id);
+                            setSelectedProjectId(repo.projects[0]?.id ?? null);
+                          }}
+                          className={`flex-1 rounded-md border px-3 py-2 text-left text-sm transition ${
+                            isActive
+                              ? "border-slate-900 bg-slate-900 text-white"
+                              : "border-slate-200 bg-white text-slate-700 hover:border-slate-300"
+                          }`}
+                        >
+                          {label}
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => removeRepository(repo.id)}
+                          className="rounded-md border border-slate-200 px-2 py-1 text-xs text-slate-500 hover:border-rose-300 hover:text-rose-500"
+                          aria-label={`Remove ${repo.owner}/${repo.repo}`}
+                        >
+                          ×
+                        </button>
+                      </li>
+                    );
+                  })}
+                </ul>
+              ) : (
+                <p className="text-sm text-slate-500">No repositories linked yet.</p>
+              )}
+            </div>
+            <form onSubmit={addRepository} className="space-y-3 rounded-xl border border-slate-200 bg-slate-50 p-4">
+              <p className="text-sm font-medium text-slate-800">Add repository</p>
+              <label className="flex flex-col gap-1 text-xs font-medium text-slate-600">
+                Owner
+                <input
+                  value={repoForm.owner}
+                  onChange={handleRepoFormChange("owner")}
+                  placeholder="acme-co"
+                  className="rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-slate-500 focus:outline-none"
+                />
+              </label>
+              <label className="flex flex-col gap-1 text-xs font-medium text-slate-600">
+                Repository
+                <input
+                  value={repoForm.repo}
+                  onChange={handleRepoFormChange("repo")}
+                  placeholder="product-app"
+                  className="rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-slate-500 focus:outline-none"
+                />
+              </label>
+              <label className="flex flex-col gap-1 text-xs font-medium text-slate-600">
+                Display name (optional)
+                <input
+                  value={repoForm.displayName}
+                  onChange={handleRepoFormChange("displayName")}
+                  placeholder="Customer dashboard"
+                  className="rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-slate-500 focus:outline-none"
+                />
+              </label>
+              {repoError ? <p className="text-xs text-rose-600">{repoError}</p> : null}
+              <button
+                type="submit"
+                className="w-full rounded-md bg-slate-900 px-3 py-2 text-sm font-medium text-white hover:bg-slate-800"
+              >
+                Link repository
+              </button>
+            </form>
+          </aside>
+
+          <div className="space-y-8">
+            {selectedRepo ? (
+              <>
+                <section className="space-y-4">
+                  <header className="space-y-1">
+                    <h3 className="text-lg font-semibold text-slate-900">{selectedRepo.displayName || `${selectedRepo.owner}/${selectedRepo.repo}`}</h3>
+                    <p className="text-xs uppercase tracking-wide text-slate-500">Repository settings</p>
+                  </header>
+                  <div className="grid gap-4 sm:grid-cols-2">
+                    <label className="flex flex-col gap-1 text-xs font-medium text-slate-600">
+                      Owner
+                      <input
+                        value={selectedRepo.owner}
+                        readOnly
+                        className="rounded-md border border-slate-200 bg-slate-100 px-3 py-2 text-sm text-slate-500"
+                      />
+                    </label>
+                    <label className="flex flex-col gap-1 text-xs font-medium text-slate-600">
+                      Repository
+                      <input
+                        value={selectedRepo.repo}
+                        readOnly
+                        className="rounded-md border border-slate-200 bg-slate-100 px-3 py-2 text-sm text-slate-500"
+                      />
+                    </label>
+                    <label className="flex flex-col gap-1 text-xs font-medium text-slate-600 sm:col-span-2">
+                      Display name (optional)
+                      <input
+                        value={selectedRepo.displayName ?? ""}
+                        onChange={onRepoFieldChange("displayName")}
+                        placeholder="Internal label"
+                        className="rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-slate-500 focus:outline-none"
+                      />
+                    </label>
+                    <label className="flex flex-col gap-1 text-xs font-medium text-slate-600 sm:col-span-2">
+                      Supabase read-only checks URL
+                      <input
+                        value={selectedRepo.supabaseReadOnlyUrl ?? ""}
+                        onChange={onRepoFieldChange("supabaseReadOnlyUrl")}
+                        placeholder="https://project.supabase.co/functions/v1/read-only-checks"
+                        className="rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-slate-500 focus:outline-none"
+                      />
+                    </label>
+                    <label className="flex flex-col gap-1 text-xs font-medium text-slate-600">
+                      GitHub PAT override (optional)
+                      <input
+                        type="password"
+                        value={selectedRepo.githubPat ?? ""}
+                        onChange={onRepoFieldChange("githubPat")}
+                        placeholder="Override default token"
+                        className="rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-slate-500 focus:outline-none"
+                      />
+                    </label>
+                    <label className="flex flex-col gap-1 text-xs font-medium text-slate-600">
+                      OpenAI key override (optional)
+                      <input
+                        type="password"
+                        value={selectedRepo.openaiKey ?? ""}
+                        onChange={onRepoFieldChange("openaiKey")}
+                        placeholder="Override default key"
+                        className="rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-slate-500 focus:outline-none"
+                      />
+                    </label>
+                  </div>
+                </section>
+
+                <section className="space-y-4">
+                  <header className="flex flex-wrap items-center justify-between gap-4">
+                    <div>
+                      <h4 className="text-base font-semibold text-slate-900">Projects in this repo</h4>
+                      <p className="text-xs text-slate-500">
+                        Link Supabase probes or override keys per project. Leave blank to inherit repo defaults.
+                      </p>
+                    </div>
+                    {repoResolved?.supabaseReadOnlyUrl ? (
+                      <span className="inline-flex items-center gap-1 rounded-full bg-emerald-100 px-3 py-1 text-xs font-medium text-emerald-700">
+                        Using {supabaseSourceLabel ?? "configured"} probe
+                      </span>
+                    ) : null}
+                  </header>
+
+                  {selectedRepo.projects.length ? (
+                    <div className="flex flex-wrap gap-2">
+                      {selectedRepo.projects.map((project) => {
+                        const isActive = project.id === selectedProjectId;
+                        return (
+                          <button
+                            key={project.id}
+                            type="button"
+                            onClick={() => setSelectedProjectId(project.id)}
+                            className={`rounded-full border px-3 py-1 text-xs font-medium transition ${
+                              isActive
+                                ? "border-slate-900 bg-slate-900 text-white"
+                                : "border-slate-300 bg-white text-slate-600 hover:border-slate-400"
+                            }`}
+                          >
+                            {project.name}
+                          </button>
+                        );
+                      })}
+                    </div>
+                  ) : (
+                    <p className="text-sm text-slate-500">No projects yet — add one below.</p>
+                  )}
+
+                  {selectedProject ? (
+                    <div className="rounded-2xl border border-slate-200 bg-slate-50 p-5 space-y-4">
+                      <div className="flex items-center justify-between">
+                        <h5 className="text-sm font-semibold text-slate-900">{selectedProject.name}</h5>
+                        <button
+                          type="button"
+                          onClick={() => removeProject(selectedProject.id)}
+                          className="text-xs font-medium text-rose-500 hover:text-rose-400"
+                        >
+                          Remove project
+                        </button>
+                      </div>
+                      <div className="grid gap-4 sm:grid-cols-2">
+                        <label className="flex flex-col gap-1 text-xs font-medium text-slate-600 sm:col-span-2">
+                          Project name
+                          <input
+                            value={selectedProject.name}
+                            onChange={onProjectFieldChange("name")}
+                            className="rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-slate-500 focus:outline-none"
+                          />
+                        </label>
+                        <label className="flex flex-col gap-1 text-xs font-medium text-slate-600 sm:col-span-2">
+                          Supabase read-only checks URL
+                          <input
+                            value={selectedProject.supabaseReadOnlyUrl ?? ""}
+                            onChange={onProjectFieldChange("supabaseReadOnlyUrl")}
+                            placeholder="https://.../read-only-checks"
+                            className="rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-slate-500 focus:outline-none"
+                          />
+                        </label>
+                        <label className="flex flex-col gap-1 text-xs font-medium text-slate-600">
+                          GitHub PAT override
+                          <input
+                            type="password"
+                            value={selectedProject.githubPat ?? ""}
+                            onChange={onProjectFieldChange("githubPat")}
+                            placeholder="Inherit repo default"
+                            className="rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-slate-500 focus:outline-none"
+                          />
+                        </label>
+                        <label className="flex flex-col gap-1 text-xs font-medium text-slate-600">
+                          OpenAI key override
+                          <input
+                            type="password"
+                            value={selectedProject.openaiKey ?? ""}
+                            onChange={onProjectFieldChange("openaiKey")}
+                            placeholder="Inherit repo default"
+                            className="rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-slate-500 focus:outline-none"
+                          />
+                        </label>
+                      </div>
+                    </div>
+                  ) : null}
+
+                  <form onSubmit={addProject} className="space-y-3 rounded-2xl border border-dashed border-slate-300 p-5">
+                    <p className="text-sm font-semibold text-slate-800">Add project</p>
+                    <label className="flex flex-col gap-1 text-xs font-medium text-slate-600">
+                      Project name
+                      <input
+                        value={projectForm.name}
+                        onChange={handleProjectFormChange}
+                        placeholder="Growth experiments"
+                        className="rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-slate-500 focus:outline-none"
+                      />
+                    </label>
+                    {projectError ? <p className="text-xs text-rose-600">{projectError}</p> : null}
+                    <button
+                      type="submit"
+                      className="inline-flex items-center justify-center rounded-md bg-slate-900 px-3 py-2 text-sm font-medium text-white hover:bg-slate-800"
+                    >
+                      Add project
+                    </button>
+                  </form>
+                </section>
+              </>
+            ) : (
+              <div className="rounded-2xl border border-slate-200 bg-slate-50 p-8 text-sm text-slate-600">
+                Link a repository to configure per-project secrets.
+              </div>
+            )}
+          </div>
+        </div>
+      </section>
+
+      {error ? <p className="text-sm text-rose-600">{error}</p> : lastSaved ? <p className="text-sm text-emerald-600">Saved locally at {new Date(lastSaved).toLocaleTimeString()}.</p> : null}
+
+      <div className="flex flex-wrap items-center gap-3">
+        <button
+          type="button"
+          onClick={handleSave}
+          disabled={isSaving || !hasChanges}
+          className="inline-flex items-center gap-2 rounded-md bg-slate-900 px-4 py-2 text-sm font-medium text-white shadow-sm transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:bg-slate-400"
+        >
+          {isSaving ? "Saving" : "Save secrets"}
+        </button>
+        {!hasChanges && !isSaving ? <span className="text-xs text-slate-500">No changes to save.</span> : null}
+      </div>
+    </div>
+  );
+}

--- a/app/wizard/[state]/page.tsx
+++ b/app/wizard/[state]/page.tsx
@@ -1,0 +1,449 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+type StageTool = {
+  href: string;
+  label: string;
+  description?: string;
+};
+
+type StageConfig = {
+  label: string;
+  title: string;
+  description: string;
+  cta?: {
+    eyebrow: string;
+    title: string;
+    description: string;
+    action: { href: string; label: string };
+    note: string;
+  };
+  sections: {
+    id: string;
+    title: string;
+    summary: string;
+    checklist: { title: string; detail: string }[];
+  }[];
+  resources: { label: string; href: string }[];
+  tools?: StageTool[];
+};
+
+const STAGES = {
+  "new-idea": {
+    label: "Ideation",
+    title: "New Idea Brainstorming",
+    description:
+      "Capture and expand every spark with a persistent AI workspace that keeps your ideas tethered to future execution.",
+    cta: {
+      eyebrow: "Live AI workspace",
+      title: "Jump into the brainstorming chat",
+      description:
+        "Spin up the connected ideation thread so every idea, insight, and follow-up question stays linked to this project.",
+      action: {
+        href: "/wizard/brainstorm",
+        label: "Launch idea workspace",
+      },
+      note: "Opens the interactive chat where each turn is saved to /tmp/ideas and can be promoted into docs/idea-log.md.",
+    },
+    tools: [
+      {
+        href: "/wizard/brainstorm",
+        label: "Launch idea workspace",
+        description:
+          "Open the AI chat that logs every turn and can be promoted into docs/idea-log.md.",
+      },
+    ],
+    sections: [
+      {
+        id: "canvas",
+        title: "Spin up your idea canvas",
+        summary:
+          "Start a connected chat workspace and define the problem, audience, and success signals before you rush into solutions.",
+        checklist: [
+          {
+            title: "Create a linked AI thread",
+            detail:
+              "Launch a project chat that stores history and can be promoted into a roadmap when you are ready to commit.",
+          },
+          {
+            title: "Map the opportunity",
+            detail:
+              "Outline core jobs-to-be-done, constraints, and differentiators. Drop links, voice notes, or sketches directly into the canvas.",
+          },
+          {
+            title: "Mark open questions",
+            detail:
+              "Flag unknowns for future discovery so the roadmap wizard can track research tasks alongside build work.",
+          },
+        ],
+      },
+      {
+        id: "transition",
+        title: "Get roadmap-ready",
+        summary:
+          "When the concept firms up, promote the session into a draft roadmap without losing any of the conversational context.",
+        checklist: [
+          {
+            title: "Highlight must-have outcomes",
+            detail: "Convert promising notes into roadmap epics with draft success metrics.",
+          },
+          {
+            title: "Attach reference material",
+            detail: "Upload PDFs, competitor teardowns, or market research so execution always stays grounded in your insight.",
+          },
+          {
+            title: "Review with collaborators",
+            detail: "Share the board or export a brief for feedback before moving into the build planning flow.",
+          },
+        ],
+      },
+    ],
+    resources: [
+      { label: "Back to wizard", href: "/wizard" },
+      { label: "Launch idea workspace", href: "/wizard/brainstorm" },
+    ],
+  },
+  concept: {
+    label: "Roadmap Drafting",
+    title: "Firm Concept, Missing Roadmap",
+    description:
+      "Turn your concept brief into an actionable roadmap, complete with generated project files, integrations, and automation hooks.",
+    cta: {
+      eyebrow: "Roadmap workspace",
+      title: "Draft docs/roadmap.yml from your brief",
+      description:
+        "Open the guided flow to paste concept notes, upload supporting files, and generate a YAML roadmap before committing it to your repo.",
+      action: {
+        href: "/wizard/concept/workspace",
+        label: "Open roadmap drafting workspace",
+      },
+      note: "Launches the upload + AI generation experience with repo commit controls.",
+    },
+    tools: [
+      {
+        href: "/wizard/concept/workspace",
+        label: "Open roadmap drafting workspace",
+        description:
+          "Paste your brief or upload a file, generate docs/roadmap.yml, and commit it to the repo.",
+      },
+    ],
+    sections: [
+      {
+        id: "ingest",
+        title: "Import and align context",
+        summary:
+          "Upload your concept doc or pull in an existing AI conversation so the wizard understands scope, goals, and guardrails.",
+        checklist: [
+          {
+            title: "Link supporting chats",
+            detail: "Attach brainstorming threads so the assistant can reference prior thinking during roadmap generation.",
+          },
+          {
+            title: "Clarify constraints",
+            detail: "Call out timelines, team capacity, and tech stack preferences so the plan reflects reality.",
+          },
+          {
+            title: "Set success metrics",
+            detail: "Define the signals that tell you the launch worked — adoption, revenue, activation, or retention goals.",
+          },
+        ],
+      },
+      {
+        id: "scaffold",
+        title: "Generate the execution scaffold",
+        summary:
+          "Translate the concept into docs/roadmap.yml, docs/gtm-plan.md, and integration-ready placeholders with one click.",
+        checklist: [
+          {
+            title: "Draft roadmap milestones",
+            detail: "Let the wizard propose weeks, owners, and deliverables that you can edit before publishing.",
+          },
+          {
+            title: "Configure integrations",
+            detail: "Paste Supabase and GitHub secrets so automated status checks can run from day one.",
+          },
+          {
+            title: "Push to your repo",
+            detail: "Export the scaffold into your workspace and open a PR for teammates to review.",
+          },
+        ],
+      },
+    ],
+    resources: [
+      { label: "Back to wizard", href: "/wizard" },
+      { label: "Open roadmap drafting workspace", href: "/wizard/concept/workspace" },
+    ],
+  },
+  "roadmap-ready": {
+    label: "Workspace Provisioning",
+    title: "Roadmap Ready, Pre-Build",
+    description:
+      "Drop in your final roadmap and let the wizard generate the repo automations, context packs, and status surfaces you will need for build.",
+    cta: {
+      eyebrow: "Provisioning workspace",
+      title: "Import roadmap.yml and scaffold automations",
+      description:
+        "Upload your existing docs/roadmap.yml, validate it, and generate infra facts, tech stack, and roadmap workflow files in one flow.",
+      action: {
+        href: "/wizard/roadmap/workspace",
+        label: "Launch provisioning workspace",
+      },
+      note: "Commits docs/roadmap.yml along with docs/infra-facts.md, docs/tech-stack.yml, and .github/workflows/roadmap.yml if they are missing.",
+    },
+    tools: [
+      {
+        href: "/wizard/roadmap/workspace",
+        label: "Launch provisioning workspace",
+        description:
+          "Upload an existing roadmap.yml, validate it, and scaffold infra-facts, tech stack, and roadmap workflow files.",
+      },
+      {
+        href: "/dashboard?tab=gtm",
+        label: "Open GTM plan workspace",
+        description:
+          "Jump into the dashboard GTM tab to scaffold docs/gtm-plan.md alongside your connected repository.",
+      },
+    ],
+    sections: [
+      {
+        id: "sync",
+        title: "Sync roadmap artifacts",
+        summary:
+          "Upload or paste your roadmap so docs/roadmap.yml, docs/tech-stack.yml, and docs/gtm-plan.md reflect the latest thinking.",
+        checklist: [
+          {
+            title: "Validate milestones",
+            detail: "Confirm epics, owners, and dependencies are tagged so progress tracking stays precise.",
+          },
+          {
+            title: "Align GTM + build",
+            detail: "Map GTM beats to engineering sprints so launches feel coordinated from the start.",
+          },
+          {
+            title: "Generate summary context",
+            detail: "Publish docs/summary.txt so any AI agent can ramp instantly.",
+          },
+        ],
+      },
+      {
+        id: "integrate",
+        title: "Wire automations",
+        summary:
+          "Provision GitHub workflows, Supabase access, and context feeds that keep roadmap status live once development begins.",
+        checklist: [
+          {
+            title: "Connect GitHub",
+            detail: "Authorize the wizard to push scaffolding commits or open pull requests in your repo.",
+          },
+          {
+            title: "Link Supabase",
+            detail: "Share read-only credentials so discovery runs can analyze schema and row-level security.",
+          },
+          {
+            title: "Schedule status reports",
+            detail: "Decide how often docs/roadmap-status.json should refresh and who receives updates.",
+          },
+        ],
+      },
+    ],
+    resources: [
+      { label: "Back to wizard", href: "/wizard" },
+      { label: "Launch provisioning workspace", href: "/wizard/roadmap/workspace" },
+      { label: "Open GTM plan workspace", href: "/dashboard?tab=gtm" },
+    ],
+  },
+  "mid-build": {
+    label: "Discovery Mode",
+    title: "Mid-Project Build",
+    description:
+      "Overlay discovery mode on your live project so AI copilots see what changed, what shipped, and what needs attention next.",
+    cta: {
+      eyebrow: "Current state sync",
+      title: "Refresh roadmap status before diving in",
+      description:
+        "Launch the mid-project sync workspace to run /api/run and /api/discover, then preview the updated status grid and backlog list.",
+      action: {
+        href: "/wizard/midproject/workspace",
+        label: "Launch mid-project sync",
+      },
+      note: "Generates docs/roadmap-status.json, docs/project-plan.md, and docs/backlog-discovered.yml so the dashboard is already current.",
+    },
+    tools: [
+      {
+        href: "/wizard/midproject/workspace",
+        label: "Launch mid-project sync",
+        description:
+          "Run status + discover workflows and preview backlog discoveries before opening the dashboard.",
+      },
+    ],
+    sections: [
+      {
+        id: "ingest",
+        title: "Load current context",
+        summary:
+          "Pull the latest code, Supabase schema, and roadmap status so the wizard reflects reality before any new suggestions drop.",
+        checklist: [
+          {
+            title: "Scan the repo",
+            detail: "Index commits, open PRs, and drift from docs/roadmap.yml to understand real progress.",
+          },
+          {
+            title: "Run discovery checks",
+            detail: "Use the discover API to surface off-roadmap work or regressions that need triage.",
+          },
+          {
+            title: "Regenerate context pack",
+            detail: "Publish a fresh bundle for your AI teammates so they jump in fully briefed.",
+          },
+        ],
+      },
+      {
+        id: "plan",
+        title: "Shape the next sprint",
+        summary:
+          "Blend roadmap goals with discovered insights to keep the build plan accurate and resilient.",
+        checklist: [
+          {
+            title: "Prioritize surfaced work",
+            detail: "Accept or reject the discover list so roadmap status stays trustworthy.",
+          },
+          {
+            title: "Update success metrics",
+            detail: "Refine targets based on what you have learned mid-flight.",
+          },
+          {
+            title: "Loop in your AI partner",
+            detail: "Assign coding tasks or ask for implementation help backed by the refreshed context pack.",
+          },
+        ],
+      },
+    ],
+    resources: [
+      { label: "Back to wizard", href: "/wizard" },
+      { label: "Launch mid-project sync", href: "/wizard/midproject/workspace" },
+      { label: "Run discovery workflow", href: "/wizard/midproject/workspace#discover" },
+    ],
+  },
+} as const satisfies Record<string, StageConfig>;
+
+type StageKey = keyof typeof STAGES;
+
+type WizardStatePageProps = {
+  params: { state: string };
+};
+
+export default function WizardStatePage({ params }: WizardStatePageProps) {
+  const stageKey = params.state as StageKey;
+  const stage = STAGES[stageKey];
+
+  if (!stage) {
+    notFound();
+  }
+
+  return (
+    <section className="tw-space-y-10">
+      <div className="tw-space-y-3">
+        <Link
+          href="/wizard"
+          className="tw-inline-flex tw-items-center tw-gap-2 tw-text-sm tw-text-slate-300 tw-transition tw-duration-200 tw-ease-out hover:tw-text-slate-100"
+        >
+          <span aria-hidden="true">←</span>
+          <span>Back to wizard</span>
+        </Link>
+        <span className="tw-inline-flex tw-items-center tw-gap-2 tw-rounded-full tw-border tw-border-slate-800 tw-px-3 tw-py-1 tw-text-xs tw-font-medium tw-uppercase tw-tracking-wide tw-text-slate-300">
+          {stage.label}
+        </span>
+        <h1 className="tw-text-3xl tw-font-bold tw-leading-tight tw-text-slate-100">{stage.title}</h1>
+        <p className="tw-text-lg tw-leading-relaxed tw-text-slate-300">{stage.description}</p>
+      </div>
+
+      {stage.cta && (
+        <div className="tw-rounded-3xl tw-border tw-border-blue-500/40 tw-bg-blue-500/10 tw-p-6 tw-flex tw-flex-col tw-gap-4">
+          <div className="tw-space-y-2">
+            <span className="tw-inline-flex tw-items-center tw-gap-2 tw-rounded-full tw-border tw-border-blue-500/40 tw-bg-blue-500/10 tw-px-3 tw-py-1 tw-text-xs tw-font-semibold tw-uppercase tw-tracking-wide tw-text-blue-200">
+              {stage.cta.eyebrow}
+            </span>
+            <h2 className="tw-text-2xl tw-font-semibold tw-text-blue-100">{stage.cta.title}</h2>
+            <p className="tw-text-sm tw-leading-relaxed tw-text-blue-100/80">{stage.cta.description}</p>
+          </div>
+          <div className="tw-flex tw-flex-wrap tw-items-center tw-gap-3">
+            <Link
+              href={stage.cta.action.href}
+              className="tw-inline-flex tw-items-center tw-gap-2 tw-rounded-full tw-bg-blue-500 tw-px-4 tw-py-2 tw-text-sm tw-font-semibold tw-text-blue-50 tw-shadow-lg tw-shadow-blue-500/30 tw-transition tw-duration-200 tw-ease-out hover:tw-bg-blue-400"
+            >
+              <span>{stage.cta.action.label}</span>
+              <span aria-hidden="true">→</span>
+            </Link>
+            <p className="tw-text-xs tw-text-blue-100/70">{stage.cta.note}</p>
+          </div>
+        </div>
+      )}
+
+      {stage.tools?.length ? (
+        <div className="tw-space-y-3">
+          <h2 className="tw-text-sm tw-font-semibold tw-uppercase tw-tracking-wide tw-text-slate-300">
+            Access the workspace
+          </h2>
+          <div className="tw-flex tw-flex-wrap tw-items-center tw-gap-3">
+            {stage.tools.map((tool) => (
+              <Link
+                key={tool.href}
+                href={tool.href}
+                className="tw-inline-flex tw-items-center tw-gap-2 tw-rounded-full tw-border tw-border-slate-700 tw-bg-slate-900 tw-px-4 tw-py-2 tw-text-sm tw-font-semibold tw-text-slate-200 tw-transition tw-duration-200 tw-ease-out hover:tw-border-slate-600 hover:tw-text-slate-100"
+              >
+                <span>{tool.label}</span>
+                <span aria-hidden="true">↗</span>
+              </Link>
+            ))}
+          </div>
+          {stage.tools.some((tool) => Boolean(tool.description)) ? (
+            <ul className="tw-space-y-1 tw-text-xs tw-text-slate-400">
+              {stage.tools.map((tool) =>
+                tool.description ? (
+                  <li key={`${tool.href}-description`}>{tool.description}</li>
+                ) : null,
+              )}
+            </ul>
+          ) : null}
+        </div>
+      ) : null}
+
+      <div className="tw-grid tw-gap-6 md:tw-grid-cols-2">
+        {stage.sections.map((section) => (
+          <div
+            key={section.id}
+            className="tw-rounded-3xl tw-border tw-border-slate-800 tw-bg-slate-900 tw-p-6 tw-flex tw-flex-col tw-gap-4"
+          >
+            <div className="tw-space-y-2">
+              <h2 className="tw-text-xl tw-font-semibold tw-leading-snug tw-text-slate-100">{section.title}</h2>
+              <p className="tw-text-sm tw-leading-relaxed tw-text-slate-300">{section.summary}</p>
+            </div>
+            <ul className="tw-space-y-2 tw-text-sm tw-text-slate-300 tw-list-disc tw-pl-5">
+              {section.checklist.map((item) => (
+                <li key={item.title} className="tw-leading-relaxed">
+                  <span className="tw-font-medium tw-text-slate-100 tw-block">{item.title}</span>
+                  <span className="tw-text-slate-300">{item.detail}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ))}
+      </div>
+
+      {stage.resources.length > 0 && (
+        <div className="tw-flex tw-flex-wrap tw-gap-3">
+          {stage.resources.map((resource) => (
+            <Link
+              key={resource.label}
+              href={resource.href}
+              className="tw-inline-flex tw-items-center tw-gap-2 tw-rounded-full tw-border tw-border-slate-800 tw-px-3 tw-py-1 tw-text-sm tw-font-medium tw-text-slate-300 tw-transition tw-duration-200 tw-ease-out hover:tw-border-slate-700 hover:tw-text-slate-100"
+            >
+              <span>{resource.label}</span>
+              <span aria-hidden="true">→</span>
+            </Link>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/app/wizard/brainstorm/page.tsx
+++ b/app/wizard/brainstorm/page.tsx
@@ -1,0 +1,243 @@
+"use client";
+
+import { FormEvent, useEffect, useMemo, useRef, useState } from "react";
+import Link from "next/link";
+
+import { useResolvedSecrets } from "@/lib/use-local-secrets";
+
+type ChatMessage = {
+  role: "user" | "assistant";
+  content: string;
+};
+
+type ChatResponse = {
+  conversationId: string;
+  reply: string;
+};
+
+type ErrorState = {
+  title: string;
+  detail?: string;
+};
+
+export default function BrainstormPage() {
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [input, setInput] = useState("");
+  const [conversationId, setConversationId] = useState<string | null>(null);
+  const [isSending, setIsSending] = useState(false);
+  const [error, setError] = useState<ErrorState | null>(null);
+  const [promoteMessage, setPromoteMessage] = useState<string | null>(null);
+  const [isPromoting, setIsPromoting] = useState(false);
+  const bottomRef = useRef<HTMLDivElement | null>(null);
+  const secrets = useResolvedSecrets();
+  const openAiConfigured = Boolean(secrets.openaiKey);
+
+  useEffect(() => {
+    if (bottomRef.current) {
+      bottomRef.current.scrollIntoView({ behavior: "smooth" });
+    }
+  }, [messages]);
+
+  const hasMessages = messages.length > 0;
+
+  const placeholder = useMemo(
+    () =>
+      "Describe the spark you want to explore, customer pain points, or constraints. The ideation partner will help you expand it.",
+    [],
+  );
+
+  async function sendMessage(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setPromoteMessage(null);
+
+    const trimmed = input.trim();
+    if (!trimmed) {
+      return;
+    }
+
+    const pendingHistory = messages;
+    const payload = {
+      conversationId,
+      history: pendingHistory,
+      message: trimmed,
+    };
+
+    setMessages((prev) => [...prev, { role: "user", content: trimmed }]);
+    setInput("");
+    setIsSending(true);
+    setError(null);
+
+    try {
+      const headers: HeadersInit = {
+        "Content-Type": "application/json",
+      };
+      if (secrets.openaiKey) {
+        headers["x-openai-key"] = secrets.openaiKey;
+      }
+
+      const response = await fetch("/api/brainstorm/chat", {
+        method: "POST",
+        headers,
+        body: JSON.stringify(payload),
+      });
+
+      if (!response.ok) {
+        const detail = await response.json().catch(() => ({}));
+        const title = typeof detail.error === "string" ? detail.error : "We could not reach OpenAI.";
+        const info = typeof detail.detail === "string" ? detail.detail : undefined;
+        setError({ title, detail: info });
+        setMessages((prev) => prev.slice(0, -1));
+        return;
+      }
+
+      const data = (await response.json()) as ChatResponse;
+      setConversationId(data.conversationId);
+      setMessages((prev) => [...prev, { role: "assistant", content: data.reply }]);
+    } catch (err) {
+      setError({ title: "Something went wrong sending your idea.", detail: err instanceof Error ? err.message : undefined });
+      setMessages((prev) => prev.slice(0, -1));
+    } finally {
+      setIsSending(false);
+    }
+  }
+
+  async function handlePromote() {
+    if (!hasMessages) {
+      return;
+    }
+
+    setIsPromoting(true);
+    setPromoteMessage(null);
+    setError(null);
+
+    try {
+      const headers: HeadersInit = {
+        "Content-Type": "application/json",
+      };
+      if (secrets.githubPat) {
+        headers["x-github-pat"] = secrets.githubPat;
+      }
+
+      const response = await fetch("/api/brainstorm/promote", {
+        method: "POST",
+        headers,
+        body: JSON.stringify({ conversationId, messages }),
+      });
+
+      if (!response.ok) {
+        const detail = await response.json().catch(() => ({}));
+        const title = typeof detail.error === "string" ? detail.error : "Failed to promote idea to project.";
+        const info = typeof detail.detail === "string" ? detail.detail : undefined;
+        setError({ title, detail: info });
+        return;
+      }
+
+      setPromoteMessage("Idea log exported to docs/idea-log.md. You can now turn this into a roadmap.");
+    } catch (err) {
+      setError({ title: "Promotion failed", detail: err instanceof Error ? err.message : undefined });
+    } finally {
+      setIsPromoting(false);
+    }
+  }
+
+  return (
+    <section className="tw-space-y-8">
+      <div className="tw-space-y-3">
+        <Link
+          href="/wizard/new-idea"
+          className="tw-inline-flex tw-items-center tw-gap-2 tw-text-sm tw-text-slate-300 tw-transition tw-duration-200 tw-ease-out hover:tw-text-slate-100"
+        >
+          <span aria-hidden="true">←</span>
+          <span>Back to ideation playbook</span>
+        </Link>
+        <h1 className="tw-text-3xl tw-font-bold tw-leading-tight tw-text-slate-100">Idea Workspace</h1>
+        <p className="tw-text-lg tw-leading-relaxed tw-text-slate-300">
+          Capture every spark in a persistent chat, let AI riff with you, and convert the best ideas into roadmap-ready context.
+        </p>
+        <div className="tw-flex tw-flex-wrap tw-gap-3">
+          <button
+            type="button"
+            className="tw-inline-flex tw-items-center tw-gap-2 tw-rounded-full tw-border tw-border-slate-800 tw-bg-slate-900 tw-px-4 tw-py-2 tw-text-sm tw-font-medium tw-text-slate-100 tw-transition tw-duration-200 tw-ease-out hover:tw-border-slate-700 disabled:tw-opacity-60"
+            onClick={handlePromote}
+            disabled={!hasMessages || isPromoting}
+          >
+            {isPromoting ? "Exporting…" : "Promote to Project"}
+          </button>
+          <span className="tw-text-sm tw-text-slate-400">
+            Each turn is saved to <code className="tw-text-xs">/tmp/ideas</code> so you can reuse the transcript later.
+          </span>
+      </div>
+      </div>
+
+      {error && (
+        <div className="tw-rounded-2xl tw-border tw-border-red-500/40 tw-bg-red-500/10 tw-p-4 tw-text-sm tw-text-red-200">
+          <p className="tw-font-semibold">{error.title}</p>
+          {error.detail && <p className="tw-mt-1 tw-text-red-200">{error.detail}</p>}
+        </div>
+      )}
+
+      {promoteMessage && (
+        <div className="tw-rounded-2xl tw-border tw-border-emerald-500/40 tw-bg-emerald-500/10 tw-p-4 tw-text-sm tw-text-emerald-200">
+          {promoteMessage}
+        </div>
+      )}
+
+      <div className="tw-flex tw-flex-col tw-gap-4 tw-rounded-3xl tw-border tw-border-slate-800 tw-bg-slate-900 tw-p-6 tw-max-h-[60vh] tw-overflow-y-auto">
+        {hasMessages ? (
+          messages.map((message, index) => (
+            <div
+              key={`${message.role}-${index}`}
+              className={
+                message.role === "user"
+                  ? "tw-ml-auto tw-max-w-[75%] tw-rounded-2xl tw-bg-slate-800 tw-px-4 tw-py-3 tw-text-sm tw-text-slate-100"
+                  : "tw-mr-auto tw-max-w-[75%] tw-rounded-2xl tw-bg-slate-950 tw-px-4 tw-py-3 tw-text-sm tw-text-slate-200"
+              }
+            >
+              <p className="tw-text-xs tw-font-semibold tw-uppercase tw-tracking-wide tw-text-slate-400">
+                {message.role === "user" ? "You" : "AI Partner"}
+              </p>
+              <p className="tw-mt-1 tw-whitespace-pre-line">{message.content}</p>
+            </div>
+          ))
+        ) : (
+          <div className="tw-text-sm tw-text-slate-400">
+            Start a conversation with your idea. The assistant will help you shape, expand, and stress-test it.
+          </div>
+        )}
+        <div ref={bottomRef} />
+      </div>
+
+      <form onSubmit={sendMessage} className="tw-space-y-3">
+        <label htmlFor="brainstorm-input" className="tw-text-sm tw-font-medium tw-text-slate-200">
+          Drop your next thought
+        </label>
+        <textarea
+          id="brainstorm-input"
+          className="tw-min-h-[140px] tw-rounded-3xl tw-border tw-border-slate-800 tw-bg-slate-950 tw-p-4 tw-text-sm tw-text-slate-100 focus:tw-border-slate-700"
+          placeholder={placeholder}
+          value={input}
+          onChange={(event) => setInput(event.target.value)}
+          disabled={isSending}
+        />
+        <div className="tw-flex tw-items-center tw-justify-between">
+          <p className="tw-text-xs tw-text-slate-400">
+            {openAiConfigured ? (
+              <span>Using your saved OpenAI key from Settings.</span>
+            ) : (
+              <span>
+                Add an OpenAI key in <Link href="/settings">Settings</Link> so the assistant can respond.
+              </span>
+            )}
+          </p>
+          <button
+            type="submit"
+            className="tw-inline-flex tw-items-center tw-gap-2 tw-rounded-full tw-border tw-border-slate-800 tw-bg-blue-600/10 tw-px-4 tw-py-2 tw-text-sm tw-font-semibold tw-text-blue-200 tw-transition tw-duration-200 tw-ease-out hover:tw-border-blue-500/60 disabled:tw-opacity-60"
+            disabled={isSending || !input.trim()}
+          >
+            {isSending ? "Thinking…" : "Send idea"}
+          </button>
+        </div>
+      </form>
+    </section>
+  );
+}

--- a/app/wizard/concept/workspace/page.tsx
+++ b/app/wizard/concept/workspace/page.tsx
@@ -1,0 +1,596 @@
+"use client";
+
+import {
+  ChangeEvent,
+  FormEvent,
+  Suspense,
+  UIEvent,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import Link from "next/link";
+import { useSearchParams } from "next/navigation";
+
+import { describeProjectFile, normalizeProjectKey } from "@/lib/project-paths";
+import { useLocalSecrets, useResolvedSecrets } from "@/lib/use-local-secrets";
+
+type ErrorState = { title: string; detail?: string } | null;
+type SuccessState = { message: string; prUrl?: string } | null;
+
+type GenerateResponse = { roadmap: string };
+
+type CommitResponse = {
+  ok: boolean;
+  branch?: string;
+  prUrl?: string;
+  pullRequestNumber?: number;
+  error?: string;
+  detail?: string;
+};
+
+type UploadState = {
+  name: string;
+  sizeLabel: string;
+};
+
+function escapeHtml(value: string) {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function highlightYaml(value: string) {
+  return value
+    .split("\n")
+    .map((line) => {
+      if (!line) {
+        return "";
+      }
+
+      const hashIndex = line.indexOf("#");
+      let main = line;
+      let comment = "";
+      if (hashIndex !== -1) {
+        main = line.slice(0, hashIndex);
+        comment = line.slice(hashIndex);
+      }
+
+      const indentMatch = main.match(/^(\s*)/);
+      const indent = indentMatch ? indentMatch[0] : "";
+      let rest = main.slice(indent.length);
+      let html = escapeHtml(indent);
+
+      if (rest.startsWith("- ")) {
+        html += '<span class="token-dash">- </span>';
+        rest = rest.slice(2);
+      }
+
+      const keyMatch = rest.match(/^([^:]+):(.*)$/);
+      if (keyMatch) {
+        const [, key, rawValue] = keyMatch;
+        const trimmedKey = key.trimEnd();
+        const spacing = key.slice(trimmedKey.length);
+        const valuePart = rawValue ?? "";
+        html += `<span class="token-key">${escapeHtml(trimmedKey)}</span>`;
+        if (spacing) {
+          html += escapeHtml(spacing);
+        }
+        html += '<span class="token-colon">:</span>';
+        if (valuePart.trim()) {
+          html += `<span class="token-string">${escapeHtml(valuePart)}</span>`;
+        } else if (valuePart) {
+          html += escapeHtml(valuePart);
+        }
+      } else {
+        html += escapeHtml(rest);
+      }
+
+      if (comment) {
+        html += `<span class="token-comment">${escapeHtml(comment)}</span>`;
+      }
+
+      return html;
+    })
+    .join("\n");
+}
+
+function formatBytes(bytes: number) {
+  if (Number.isNaN(bytes) || bytes <= 0) {
+    return "0 B";
+  }
+  const units = ["B", "KB", "MB", "GB"];
+  let value = bytes;
+  let unitIndex = 0;
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024;
+    unitIndex += 1;
+  }
+  return `${value.toFixed(value < 10 && unitIndex > 0 ? 1 : 0)} ${units[unitIndex]}`;
+}
+
+function ConceptWizardPageInner() {
+  const params = useSearchParams();
+  const [owner, setOwner] = useState(() => params.get("owner") ?? "");
+  const [repo, setRepo] = useState(() => params.get("repo") ?? "");
+  const [branch, setBranch] = useState(() => params.get("branch") ?? "main");
+  const [project, setProject] = useState(() => params.get("project") ?? "");
+  const [conceptText, setConceptText] = useState("");
+  const [upload, setUpload] = useState<UploadState | null>(null);
+  const [uploadText, setUploadText] = useState("");
+  const [filePickerKey, setFilePickerKey] = useState(0);
+  const [isGenerating, setIsGenerating] = useState(false);
+  const [roadmap, setRoadmap] = useState("");
+  const [error, setError] = useState<ErrorState>(null);
+  const [success, setSuccess] = useState<SuccessState>(null);
+  const [openAsPr, setOpenAsPr] = useState(false);
+  const [isCommitting, setIsCommitting] = useState(false);
+  const previewRef = useRef<HTMLPreElement | null>(null);
+  const editorRef = useRef<HTMLTextAreaElement | null>(null);
+  const secretsStore = useLocalSecrets();
+  const secrets = useResolvedSecrets(owner, repo, project || undefined);
+  const openAiConfigured = Boolean(secrets.openaiKey);
+  const githubConfigured = Boolean(secrets.githubPat);
+  const repoEntries = secretsStore.repos;
+  const repoSlug = useMemo(() => {
+    const ownerSlug = owner.trim().toLowerCase();
+    const repoSlugValue = repo.trim().toLowerCase();
+    return ownerSlug && repoSlugValue ? `${ownerSlug}/${repoSlugValue}` : "";
+  }, [owner, repo]);
+  const matchedRepoEntry = useMemo(() => {
+    if (!repoSlug) return undefined;
+    return repoEntries.find(
+      (entry) => `${entry.owner.toLowerCase()}/${entry.repo.toLowerCase()}` === repoSlug,
+    );
+  }, [repoEntries, repoSlug]);
+  const projectOptions = useMemo(() => matchedRepoEntry?.projects ?? [], [matchedRepoEntry]);
+  const activeProjectId = useMemo(() => {
+    if (!project) return "";
+    const matchById = projectOptions.find((option) => option.id === project);
+    if (matchById) return matchById.id;
+    const normalized = normalizeProjectKey(project);
+    const matchByKey = projectOptions.find((option) => normalizeProjectKey(option.id) === normalized);
+    return matchByKey?.id ?? project;
+  }, [project, projectOptions]);
+
+  const combinedPrompt = useMemo(() => {
+    if (conceptText && uploadText) {
+      return `${conceptText.trim()}\n\nUploaded context:\n${uploadText.trim()}`;
+    }
+    if (conceptText) return conceptText.trim();
+    if (uploadText) return uploadText.trim();
+    return "";
+  }, [conceptText, uploadText]);
+
+  const highlighted = useMemo(() => highlightYaml(roadmap || ""), [roadmap]);
+
+  useEffect(() => {
+    if (previewRef.current && editorRef.current) {
+      previewRef.current.scrollTop = editorRef.current.scrollTop;
+      previewRef.current.scrollLeft = editorRef.current.scrollLeft;
+    }
+  }, [roadmap]);
+
+  const canGenerate = Boolean(!isGenerating && combinedPrompt);
+  const projectKey = normalizeProjectKey(project);
+  const targetPath = describeProjectFile("docs/roadmap.yml", projectKey);
+  const canCommit = Boolean(!isCommitting && roadmap.trim() && owner && repo && branch);
+
+  async function onGenerate(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!combinedPrompt) {
+      setError({ title: "Provide concept details", detail: "Paste text or upload a document before generating." });
+      return;
+    }
+
+    setIsGenerating(true);
+    setError(null);
+    setSuccess(null);
+
+    try {
+      const headers: HeadersInit = { "Content-Type": "application/json" };
+      if (secrets.openaiKey) {
+        headers["x-openai-key"] = secrets.openaiKey;
+      }
+
+      const response = await fetch("/api/concept/generate", {
+        method: "POST",
+        headers,
+        body: JSON.stringify({ prompt: combinedPrompt }),
+      });
+
+      if (!response.ok) {
+        const detail = await response.json().catch(() => ({}));
+        const title = typeof detail.error === "string" ? detail.error : "Failed to generate roadmap";
+        const info = typeof detail.detail === "string" ? detail.detail : undefined;
+        setError({ title, detail: info });
+        return;
+      }
+
+      const data = (await response.json()) as GenerateResponse;
+      setRoadmap(data.roadmap.trim());
+      setSuccess({ message: "Draft roadmap ready. Review and edit before committing to your repo." });
+    } catch (err) {
+      setError({ title: "Generation failed", detail: err instanceof Error ? err.message : String(err) });
+    } finally {
+      setIsGenerating(false);
+    }
+  }
+
+  function syncScroll(event: UIEvent<HTMLTextAreaElement>) {
+    const target = event.currentTarget;
+    if (previewRef.current) {
+      previewRef.current.scrollTop = target.scrollTop;
+      previewRef.current.scrollLeft = target.scrollLeft;
+    }
+  }
+
+  function onFileChange(event: ChangeEvent<HTMLInputElement>) {
+    const file = event.target.files?.[0];
+    if (!file) {
+      setUpload(null);
+      setUploadText("");
+      setFilePickerKey((value) => value + 1);
+      return;
+    }
+    if (file.size > 2 * 1024 * 1024) {
+      setError({ title: "File too large", detail: "Limit uploads to 2MB text documents." });
+      event.target.value = "";
+      setFilePickerKey((value) => value + 1);
+      return;
+    }
+
+    const reader = new FileReader();
+    reader.onload = () => {
+      const text = typeof reader.result === "string" ? reader.result : "";
+      setUpload({ name: file.name, sizeLabel: formatBytes(file.size) });
+      setUploadText(text.trim());
+    };
+    reader.onerror = () => {
+      setError({ title: "Failed to read file", detail: "Try uploading a plain text or markdown document." });
+      setUpload(null);
+      setUploadText("");
+      setFilePickerKey((value) => value + 1);
+    };
+    reader.readAsText(file);
+  }
+
+  function resetUpload() {
+    setUpload(null);
+    setUploadText("");
+    setFilePickerKey((value) => value + 1);
+  }
+
+  async function onCommit() {
+    if (!roadmap.trim()) {
+      setError({ title: "Roadmap is empty", detail: "Generate or paste roadmap content before committing." });
+      return;
+    }
+    if (!owner || !repo) {
+      setError({ title: "Connect a repo", detail: "Provide owner and repo so the wizard can push docs/roadmap.yml." });
+      return;
+    }
+
+    setIsCommitting(true);
+    setError(null);
+    setSuccess(null);
+
+    try {
+      const headers: HeadersInit = { "Content-Type": "application/json" };
+      if (secrets.githubPat) {
+        headers["x-github-pat"] = secrets.githubPat;
+      }
+
+      const endpoint = openAsPr ? "/api/concept/commit?asPR=true" : "/api/concept/commit";
+      const response = await fetch(endpoint, {
+        method: "POST",
+        headers,
+        body: JSON.stringify({ owner, repo, branch: branch || "main", content: roadmap, project: project || undefined }),
+      });
+
+      const detail = (await response.json().catch(() => ({}))) as CommitResponse;
+
+      if (!response.ok) {
+        const title = typeof detail?.error === "string" ? detail.error : "Commit failed";
+        const info = typeof detail?.detail === "string" ? detail.detail : undefined;
+        setError({ title, detail: info });
+        return;
+      }
+
+      if (detail.ok) {
+        if (openAsPr) {
+          if (detail.prUrl) {
+            const label = detail.pullRequestNumber ? `PR #${detail.pullRequestNumber}` : "Pull request";
+            setSuccess({
+              message: `${label} opened for ${targetPath}.`,
+              prUrl: detail.prUrl,
+            });
+          } else {
+            setSuccess({
+              message: `Pull request opened for ${targetPath}. Check GitHub to review and merge.`,
+            });
+          }
+        } else {
+          const targetBranch = detail.branch ?? branch;
+          setSuccess({ message: `${targetPath} committed to ${targetBranch}.` });
+        }
+      } else {
+        setError({ title: detail?.error ?? "Unexpected response", detail: detail?.detail });
+      }
+    } catch (err) {
+      setError({ title: "Commit failed", detail: err instanceof Error ? err.message : String(err) });
+    } finally {
+      setIsCommitting(false);
+    }
+  }
+
+  return (
+    <section className="tw-space-y-8">
+      <div className="tw-space-y-3">
+        <Link
+          href="/wizard/concept"
+          prefetch={false}
+          className="tw-inline-flex tw-items-center tw-gap-2 tw-text-sm tw-text-slate-300 tw-transition tw-duration-200 tw-ease-out hover:tw-text-slate-100"
+        >
+          <span aria-hidden="true">←</span>
+          <span>Back to roadmap playbook</span>
+        </Link>
+        <h1 className="tw-text-3xl tw-font-bold tw-leading-tight tw-text-slate-100">Concept to Roadmap</h1>
+        <p className="tw-text-lg tw-leading-relaxed tw-text-slate-300">
+          Paste your concept brief or upload research notes, generate a structured roadmap, and push docs/roadmap.yml to your repo.
+        </p>
+        <div className="tw-flex tw-flex-wrap tw-gap-3">
+          <span className="tw-text-xs tw-font-medium tw-uppercase tw-tracking-wide tw-text-slate-400">
+            {openAiConfigured ? "OpenAI ready" : "Add an OpenAI key in Settings"}
+          </span>
+          <span className="tw-text-xs tw-font-medium tw-uppercase tw-tracking-wide tw-text-slate-400">
+            {githubConfigured ? "GitHub token ready" : "Add a GitHub PAT in Settings"}
+          </span>
+        </div>
+      </div>
+
+      <form onSubmit={onGenerate} className="tw-grid tw-gap-6 tw-rounded-3xl tw-border tw-border-slate-800 tw-bg-slate-900 tw-p-6">
+        <div className="tw-space-y-2">
+          <label className="tw-text-sm tw-font-medium tw-text-slate-200">Concept notes</label>
+          <textarea
+            value={conceptText}
+            onChange={(event) => setConceptText(event.target.value)}
+            className="tw-min-h-[160px] tw-w-full tw-resize-y tw-rounded-2xl tw-border tw-border-slate-800 tw-bg-slate-950/80 tw-p-4 tw-text-sm tw-text-slate-100 tw-outline-none focus:tw-border-slate-600"
+            placeholder="Paste the problem statement, audience, constraints, or existing brainstorming transcript."
+          />
+        </div>
+
+        <div className="tw-space-y-2">
+          <label className="tw-text-sm tw-font-medium tw-text-slate-200">Or upload supporting brief</label>
+          <div className="tw-flex tw-flex-wrap tw-items-center tw-justify-between tw-gap-3 tw-rounded-2xl tw-border tw-border-dashed tw-border-slate-700 tw-bg-slate-950/60 tw-p-4">
+            <div className="tw-space-y-1">
+              <p className="tw-text-sm tw-font-medium tw-text-slate-100">Attach markdown, text, or YAML exports</p>
+              <p className="tw-text-xs tw-text-slate-400">.md, .txt, .json, .yaml up to 2MB</p>
+              {upload && (
+                <div className="tw-text-xs tw-text-slate-300">
+                  {upload.name} <span className="tw-text-slate-500">({upload.sizeLabel})</span>
+                </div>
+              )}
+            </div>
+            <div className="tw-flex tw-items-center tw-gap-2">
+              {upload && (
+                <button
+                  type="button"
+                  onClick={resetUpload}
+                  className="tw-inline-flex tw-items-center tw-gap-1 tw-rounded-full tw-border tw-border-slate-700 tw-bg-slate-900 tw-px-3 tw-py-1 tw-text-xs tw-font-medium tw-text-slate-300 hover:tw-border-slate-600"
+                >
+                  Clear
+                </button>
+              )}
+              <label className="tw-inline-flex tw-cursor-pointer tw-items-center tw-gap-2 tw-rounded-full tw-border tw-border-slate-700 tw-bg-slate-900 tw-px-4 tw-py-2 tw-text-xs tw-font-semibold tw-uppercase tw-tracking-wide tw-text-slate-100 hover:tw-border-slate-500">
+                Upload
+                <input
+                  key={filePickerKey}
+                  type="file"
+                  accept=".md,.txt,.markdown,.yaml,.yml,.json"
+                  onChange={onFileChange}
+                  className="tw-hidden"
+                />
+              </label>
+            </div>
+          </div>
+        </div>
+
+        <div className="tw-flex tw-flex-wrap tw-items-center tw-justify-between tw-gap-3">
+          <div className="tw-text-xs tw-text-slate-400">
+            Provide either pasted context or an upload. The wizard blends both sources when available.
+          </div>
+          <button
+            type="submit"
+            disabled={!canGenerate}
+            className="tw-inline-flex tw-items-center tw-gap-2 tw-rounded-full tw-border tw-border-slate-800 tw-bg-slate-100 tw-px-4 tw-py-2 tw-text-sm tw-font-semibold tw-text-slate-900 tw-transition tw-duration-200 tw-ease-out disabled:tw-cursor-not-allowed disabled:tw-border-slate-800/60 disabled:tw-bg-slate-700/40 disabled:tw-text-slate-400 hover:tw-bg-white"
+          >
+            {isGenerating ? "Generating…" : "Generate Roadmap"}
+          </button>
+        </div>
+      </form>
+
+      {(error || success) && (
+        <div className="tw-space-y-3">
+          {error && (
+            <div className="tw-rounded-2xl tw-border tw-border-red-500/40 tw-bg-red-500/10 tw-p-4 tw-text-sm tw-text-red-200">
+              <p className="tw-font-semibold">{error.title}</p>
+              {error.detail && <p className="tw-mt-1 tw-text-xs tw-text-red-200/80">{error.detail}</p>}
+            </div>
+          )}
+          {success && !error && (
+            <div className="tw-rounded-2xl tw-border tw-border-emerald-500/40 tw-bg-emerald-500/10 tw-p-4 tw-text-sm tw-text-emerald-200 tw-space-y-2">
+              <p className="tw-font-semibold">{success.message}</p>
+              {success.prUrl && (
+                <a
+                  href={success.prUrl}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="tw-inline-flex tw-items-center tw-gap-2 tw-text-xs tw-font-semibold tw-text-emerald-200/90 hover:tw-text-emerald-100"
+                >
+                  View on GitHub
+                  <span aria-hidden="true">↗</span>
+                </a>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+
+      <div className="tw-grid tw-gap-6">
+        <header className="tw-flex tw-flex-wrap tw-items-center tw-justify-between tw-gap-3">
+          <h2 className="tw-text-xl tw-font-semibold tw-text-slate-100">{targetPath}</h2>
+          <div className="tw-flex tw-flex-wrap tw-items-center tw-gap-2">
+            <input
+              value={owner}
+              onChange={(event) => setOwner(event.target.value)}
+              placeholder="owner"
+              className="tw-w-32 tw-rounded-full tw-border tw-border-slate-800 tw-bg-slate-950/70 tw-px-3 tw-py-1.5 tw-text-xs tw-text-slate-100 focus:tw-border-slate-600"
+            />
+            <span className="tw-text-slate-400">/</span>
+            <input
+              value={repo}
+              onChange={(event) => setRepo(event.target.value)}
+              placeholder="repo"
+              className="tw-w-40 tw-rounded-full tw-border tw-border-slate-800 tw-bg-slate-950/70 tw-px-3 tw-py-1.5 tw-text-xs tw-text-slate-100 focus:tw-border-slate-600"
+            />
+            <input
+              value={branch}
+              onChange={(event) => setBranch(event.target.value)}
+              placeholder="branch"
+              className="tw-w-32 tw-rounded-full tw-border tw-border-slate-800 tw-bg-slate-950/70 tw-px-3 tw-py-1.5 tw-text-xs tw-text-slate-100 focus:tw-border-slate-600"
+            />
+            <input
+              value={project}
+              onChange={(event) => setProject(event.target.value)}
+              placeholder="project (optional)"
+              className="tw-w-44 tw-rounded-full tw-border tw-border-slate-800 tw-bg-slate-950/70 tw-px-3 tw-py-1.5 tw-text-xs tw-text-slate-100 focus:tw-border-slate-600"
+            />
+          </div>
+        </header>
+
+        {repoEntries.length > 0 && (
+          <div className="tw-rounded-2xl tw-border tw-border-slate-800 tw-bg-slate-950/60 tw-p-4 tw-space-y-3">
+            <div className="tw-flex tw-flex-wrap tw-items-center tw-justify-between tw-gap-3">
+              <h3 className="tw-text-sm tw-font-semibold tw-text-slate-200">Linked repositories</h3>
+              <p className="tw-text-xs tw-text-slate-400">Pick a repo to auto-fill owner and project settings.</p>
+            </div>
+            <div className="tw-flex tw-flex-wrap tw-gap-2">
+              {repoEntries.map((entry) => {
+                const label = entry.displayName?.trim() || `${entry.owner}/${entry.repo}`;
+                const entrySlug = `${entry.owner.toLowerCase()}/${entry.repo.toLowerCase()}`;
+                const isActive = repoSlug === entrySlug;
+                return (
+                  <button
+                    key={entry.id}
+                    type="button"
+                    onClick={() => {
+                      setOwner(entry.owner);
+                      setRepo(entry.repo);
+                      if (entry.projects.length === 1) {
+                        setProject(entry.projects[0].id);
+                      }
+                    }}
+                    className={`tw-inline-flex tw-items-center tw-gap-2 tw-rounded-full tw-border tw-px-3 tw-py-1.5 tw-text-xs tw-font-semibold tw-transition tw-duration-200 tw-ease-out ${
+                      isActive
+                        ? "tw-border-emerald-500 tw-bg-emerald-600/10 tw-text-emerald-200"
+                        : "tw-border-slate-700 tw-bg-slate-900 tw-text-slate-200 hover:tw-border-slate-600"
+                    }`}
+                  >
+                    {label}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        )}
+
+        {projectOptions.length > 0 && (
+          <div className="tw-space-y-3 tw-rounded-2xl tw-border tw-border-slate-800 tw-bg-slate-950/60 tw-p-4">
+            <div className="tw-flex tw-flex-wrap tw-items-center tw-justify-between tw-gap-3">
+              <h3 className="tw-text-sm tw-font-semibold tw-text-slate-200">Projects in {matchedRepoEntry?.displayName ?? `${owner || "repo"}`}</h3>
+              <p className="tw-text-xs tw-text-slate-400">Select a saved project or keep typing a new one above.</p>
+            </div>
+            <div className="tw-flex tw-flex-wrap tw-gap-2">
+              {projectOptions.map((option) => {
+                const isActive = activeProjectId === option.id || project === option.id;
+                return (
+                  <button
+                    key={option.id}
+                    type="button"
+                    onClick={() => setProject(option.id)}
+                    className={`tw-inline-flex tw-items-center tw-gap-2 tw-rounded-full tw-border tw-px-3 tw-py-1.5 tw-text-xs tw-font-semibold tw-transition tw-duration-200 tw-ease-out ${
+                      isActive
+                        ? "tw-border-emerald-500 tw-bg-emerald-600/10 tw-text-emerald-200"
+                        : "tw-border-slate-700 tw-bg-slate-900 tw-text-slate-200 hover:tw-border-slate-600"
+                    }`}
+                  >
+                    {option.name}
+                  </button>
+                );
+              })}
+            </div>
+            <p className="tw-text-xs tw-text-slate-400">
+              Target file: <code className="tw-font-mono tw-text-[11px]">{targetPath}</code>
+            </p>
+          </div>
+        )}
+
+        <div className="tw-flex tw-flex-wrap tw-items-center tw-justify-between tw-gap-3">
+          <label className="tw-inline-flex tw-items-center tw-gap-2 tw-rounded-full tw-border tw-border-slate-800 tw-bg-slate-950/60 tw-px-3 tw-py-1.5 tw-text-xs tw-font-medium tw-text-slate-200">
+            <input
+              type="checkbox"
+              checked={openAsPr}
+              onChange={(event) => setOpenAsPr(event.target.checked)}
+              className="tw-h-3.5 tw-w-3.5 tw-rounded tw-border tw-border-slate-700 tw-bg-slate-900 tw-text-emerald-400 focus:tw-ring-emerald-400"
+            />
+            <span>Open as pull request</span>
+          </label>
+          <button
+            type="button"
+            onClick={onCommit}
+            disabled={!canCommit}
+            className="tw-inline-flex tw-items-center tw-gap-2 tw-rounded-full tw-border tw-border-slate-800 tw-bg-emerald-400/90 tw-px-4 tw-py-2 tw-text-sm tw-font-semibold tw-text-slate-900 tw-transition tw-duration-200 tw-ease-out disabled:tw-cursor-not-allowed disabled:tw-border-slate-800/60 disabled:tw-bg-slate-700/40 disabled:tw-text-slate-400 hover:tw-bg-emerald-300"
+          >
+            {isCommitting ? "Committing…" : openAsPr ? "Open PR" : "Commit to Repo"}
+          </button>
+        </div>
+        <p className="tw-text-xs tw-text-slate-400">
+          {openAsPr
+            ? "Creates a new branch and opens a PR with the generated roadmap."
+            : `Commits ${targetPath} directly to ${branch || "main"}.`}
+        </p>
+
+        <div className="code-editor">
+          <pre
+            ref={previewRef}
+            className="code-editor__preview"
+            aria-hidden="true"
+            dangerouslySetInnerHTML={{ __html: highlighted || "" }}
+          />
+          <textarea
+            ref={editorRef}
+            value={roadmap}
+            onChange={(event) => setRoadmap(event.target.value)}
+            spellCheck={false}
+            placeholder="# Generated roadmap YAML will appear here"
+            className="code-editor__textarea"
+            onScroll={syncScroll}
+          />
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export default function ConceptWizardPage() {
+  return (
+    <Suspense fallback={<div className="tw-px-6 tw-py-10 tw-text-sm tw-text-slate-400">Loading concept workspace…</div>}>
+      <ConceptWizardPageInner />
+    </Suspense>
+  );
+}

--- a/app/wizard/midproject/page.tsx
+++ b/app/wizard/midproject/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function MidProjectWorkspaceRedirect() {
+  redirect("/wizard/midproject/workspace");
+}

--- a/app/wizard/midproject/workspace/page.tsx
+++ b/app/wizard/midproject/workspace/page.tsx
@@ -1,0 +1,929 @@
+"use client";
+
+import { ChangeEvent, FormEvent, useCallback, useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+
+import StatusGrid from "@/components/StatusGrid";
+import { describeProjectFile, normalizeProjectKey } from "@/lib/project-paths";
+import { resolveSecrets, useLocalSecrets } from "@/lib/use-local-secrets";
+
+type ErrorState = { title: string; detail?: string } | null;
+
+type RunResponse = {
+  ok?: boolean;
+  wrote?: string[];
+  error?: string;
+  detail?: string;
+};
+
+type BacklogItem = {
+  id: string;
+  title: string;
+  status: string;
+};
+
+type DiscoverConfig = {
+  db_queries: string[];
+  code_globs: string[];
+  notes?: string[];
+};
+
+type ProbeResult = { q: string; ok: boolean; why?: string };
+
+type DiscoverResponse = {
+  ok?: boolean;
+  discovered?: number;
+  items?: BacklogItem[];
+  wrote?: string[];
+  error?: string;
+  detail?: string;
+  config?: DiscoverConfig;
+  db?: ProbeResult[];
+  code_matches?: string[];
+};
+
+type RoadmapStatus = {
+  generated_at?: string;
+  weeks?: any[];
+};
+
+type ContextPack = {
+  generated_at?: string;
+  repo?: { owner?: string; name?: string; branch?: string; project?: string };
+  files?: Record<string, string>;
+};
+
+export default function MidProjectSyncWorkspace() {
+  const [owner, setOwner] = useState("");
+  const [repo, setRepo] = useState("");
+  const [branch, setBranch] = useState("main");
+  const [probeUrl, setProbeUrl] = useState("");
+  const [selectedRepoId, setSelectedRepoId] = useState("");
+  const [selectedProjectId, setSelectedProjectId] = useState("");
+  const [projectOverride, setProjectOverride] = useState("");
+  const [probeCustomized, setProbeCustomized] = useState(false);
+  const [bootstrapped, setBootstrapped] = useState(false);
+
+  const [status, setStatus] = useState<RoadmapStatus | null>(null);
+  const [backlog, setBacklog] = useState<BacklogItem[]>([]);
+  const [runArtifacts, setRunArtifacts] = useState<string[]>([]);
+  const [discoverArtifacts, setDiscoverArtifacts] = useState<string[]>([]);
+  const [discoverConfig, setDiscoverConfig] = useState<DiscoverConfig | null>(null);
+  const [dbProbes, setDbProbes] = useState<ProbeResult[]>([]);
+  const [codeMatches, setCodeMatches] = useState<string[]>([]);
+  const [lastSyncedAt, setLastSyncedAt] = useState<string | null>(null);
+  const [lastDiscoveryAt, setLastDiscoveryAt] = useState<string | null>(null);
+
+  const [error, setError] = useState<ErrorState>(null);
+  const [contextError, setContextError] = useState<ErrorState>(null);
+  const [isSyncing, setIsSyncing] = useState(false);
+  const [isDiscovering, setIsDiscovering] = useState(false);
+  const [isExporting, setIsExporting] = useState(false);
+
+  const [contextPack, setContextPack] = useState<ContextPack | null>(null);
+  const secretsStore = useLocalSecrets();
+
+  const trimmedOwner = owner.trim();
+  const trimmedRepo = repo.trim();
+
+  const repoOptions = secretsStore.repos;
+  const matchedRepoEntry = useMemo(() => {
+    if (selectedRepoId) {
+      return repoOptions.find((entry) => entry.id === selectedRepoId) ?? null;
+    }
+    if (trimmedOwner && trimmedRepo) {
+      return (
+        repoOptions.find(
+          (entry) =>
+            entry.owner.trim().toLowerCase() === trimmedOwner.toLowerCase() &&
+            entry.repo.trim().toLowerCase() === trimmedRepo.toLowerCase(),
+        ) ?? null
+      );
+    }
+    return null;
+  }, [repoOptions, selectedRepoId, trimmedOwner, trimmedRepo]);
+  const projectOptions = useMemo(() => matchedRepoEntry?.projects ?? [], [matchedRepoEntry]);
+
+  const resolvedSecrets = useMemo(
+    () => resolveSecrets(secretsStore, trimmedOwner, trimmedRepo, selectedProjectId || undefined),
+    [secretsStore, trimmedOwner, trimmedRepo, selectedProjectId],
+  );
+
+  const rawProjectInput = projectOverride.trim() || selectedProjectId;
+  const projectKey = normalizeProjectKey(rawProjectInput);
+  const roadmapPath = describeProjectFile("docs/roadmap.yml", projectKey);
+  const projectPlanPath = describeProjectFile("docs/project-plan.md", projectKey);
+  const statusPath = describeProjectFile("docs/roadmap-status.json", projectKey);
+  const discoverPath = describeProjectFile("docs/discover.yml", projectKey);
+  const backlogPath = describeProjectFile("docs/backlog-discovered.yml", projectKey);
+  const summaryPath = describeProjectFile("docs/summary.txt", projectKey);
+
+  const describeSource = (source?: "project" | "repo" | "default") => {
+    if (!source) return null;
+    if (source === "project") return "project override";
+    if (source === "repo") return "repo default";
+    return "global default";
+  };
+
+  const githubReady = Boolean(resolvedSecrets.githubPat);
+  const supabaseReady = Boolean(resolvedSecrets.supabaseReadOnlyUrl);
+  const githubSourceLabel = describeSource(resolvedSecrets.sources.githubPat);
+  const supabaseSourceLabel = describeSource(resolvedSecrets.sources.supabaseReadOnlyUrl);
+
+  const repoSlug = trimmedOwner && trimmedRepo ? `${trimmedOwner}/${trimmedRepo}` : null;
+  const dashboardHref = repoSlug
+    ? `/dashboard?owner=${encodeURIComponent(trimmedOwner)}&repo=${encodeURIComponent(trimmedRepo)}`
+    : null;
+
+  const canSubmit = Boolean(!isSyncing && repoSlug);
+  const canDiscover = Boolean(!isDiscovering && !isSyncing && repoSlug);
+  const branchParam = branch.trim() || "main";
+
+  useEffect(() => {
+    if (bootstrapped) return;
+    if (!owner && !repo && repoOptions.length) {
+      const first = repoOptions[0];
+      setSelectedRepoId(first.id);
+      setOwner(first.owner);
+      setRepo(first.repo);
+      setSelectedProjectId(first.projects[0]?.id ?? "");
+      setBootstrapped(true);
+    } else if (owner || repo) {
+      setBootstrapped(true);
+    }
+  }, [bootstrapped, owner, repo, repoOptions]);
+
+  useEffect(() => {
+    if (!projectOptions.length) {
+      if (selectedProjectId) {
+        setSelectedProjectId("");
+      }
+      if (projectOverride) {
+        setProjectOverride("");
+      }
+      return;
+    }
+    if (selectedProjectId && !projectOptions.some((project) => project.id === selectedProjectId)) {
+      setSelectedProjectId(projectOptions[0].id);
+    }
+  }, [projectOptions, projectOverride, selectedProjectId]);
+
+  useEffect(() => {
+    if (!selectedProjectId) {
+      return;
+    }
+    setProjectOverride((current) => (current ? current : selectedProjectId));
+  }, [selectedProjectId]);
+
+  useEffect(() => {
+    setProbeCustomized(false);
+  }, [selectedRepoId, selectedProjectId]);
+
+  useEffect(() => {
+    if (!probeCustomized && resolvedSecrets.supabaseReadOnlyUrl) {
+      setProbeUrl(resolvedSecrets.supabaseReadOnlyUrl);
+    }
+  }, [probeCustomized, resolvedSecrets.supabaseReadOnlyUrl]);
+
+  const handleRepoSelect = useCallback(
+    (event: ChangeEvent<HTMLSelectElement>) => {
+      const value = event.target.value;
+      if (!value) {
+        setSelectedRepoId("");
+        setSelectedProjectId("");
+        setProjectOverride("");
+        return;
+      }
+      const entry = repoOptions.find((option) => option.id === value);
+      if (!entry) return;
+      setSelectedRepoId(entry.id);
+      setOwner(entry.owner);
+      setRepo(entry.repo);
+      setSelectedProjectId(entry.projects[0]?.id ?? "");
+      setProjectOverride(entry.projects[0]?.id ?? "");
+    },
+    [repoOptions],
+  );
+
+  const handleProjectSelect = useCallback((event: ChangeEvent<HTMLSelectElement>) => {
+    const value = event.target.value;
+    setSelectedProjectId(value);
+    setProjectOverride(value);
+  }, []);
+
+  const handleProbeChange = useCallback((event: ChangeEvent<HTMLInputElement>) => {
+    setProbeCustomized(true);
+    setProbeUrl(event.target.value);
+  }, []);
+
+  const resetProbeToDefault = useCallback(() => {
+    setProbeCustomized(false);
+    if (resolvedSecrets.supabaseReadOnlyUrl) {
+      setProbeUrl(resolvedSecrets.supabaseReadOnlyUrl);
+    } else {
+      setProbeUrl("");
+    }
+  }, [resolvedSecrets.supabaseReadOnlyUrl]);
+
+  async function handleSync(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!repoSlug) {
+      setError({ title: "Provide owner and repository", detail: "Fill both fields before connecting." });
+      return;
+    }
+
+    setIsSyncing(true);
+    setError(null);
+    setStatus(null);
+    setBacklog([]);
+    setRunArtifacts([]);
+    setDiscoverArtifacts([]);
+    setDiscoverConfig(null);
+    setDbProbes([]);
+    setCodeMatches([]);
+    setContextPack(null);
+    setContextError(null);
+    setLastSyncedAt(null);
+    setLastDiscoveryAt(null);
+
+    const payload = {
+      owner: owner.trim(),
+      repo: repo.trim(),
+      branch: branch.trim() || "main",
+      ...(probeUrl.trim() ? { probeUrl: probeUrl.trim() } : {}),
+      ...(projectKey ? { project: projectKey } : {}),
+    };
+
+    try {
+      const runHeaders: HeadersInit = { "Content-Type": "application/json" };
+      if (resolvedSecrets.githubPat) {
+        runHeaders["x-github-pat"] = resolvedSecrets.githubPat;
+      }
+
+      const runResponse = await fetch("/api/run", {
+        method: "POST",
+        headers: runHeaders,
+        body: JSON.stringify(payload),
+      });
+      const runJson = (await runResponse.json()) as RunResponse;
+      if (!runResponse.ok || runJson?.ok === false || runJson?.error) {
+        throw new Error(runJson?.error || "Failed to refresh roadmap status");
+      }
+      setRunArtifacts(runJson?.wrote ?? []);
+
+      const statusHeaders: HeadersInit = resolvedSecrets.githubPat
+        ? { "x-github-pat": resolvedSecrets.githubPat }
+        : {};
+      const statusProjectQuery = projectKey ? `&project=${encodeURIComponent(projectKey)}` : "";
+      const statusResponse = await fetch(
+        `/api/status/${payload.owner}/${payload.repo}?branch=${encodeURIComponent(payload.branch)}${statusProjectQuery}`,
+        { cache: "no-store", headers: statusHeaders },
+      );
+      if (statusResponse.ok) {
+        const statusJson = (await statusResponse.json()) as RoadmapStatus;
+        setStatus(statusJson);
+      } else {
+        setStatus(null);
+      }
+
+      await runDiscovery(payload);
+
+      const nowIso = new Date().toISOString();
+      setLastSyncedAt(nowIso);
+    } catch (err: any) {
+      setError({
+        title: "Sync failed",
+        detail: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      setIsSyncing(false);
+    }
+  }
+
+  const statusGeneratedAt = status?.generated_at
+    ? new Date(status.generated_at).toLocaleString()
+    : lastSyncedAt
+    ? new Date(lastSyncedAt).toLocaleString()
+    : null;
+
+  const discoveryGeneratedAt = lastDiscoveryAt
+    ? new Date(lastDiscoveryAt).toLocaleString()
+    : null;
+
+  const seededDiscover = useMemo(
+    () => (discoverPath ? discoverArtifacts.some((path) => path.startsWith(discoverPath)) : false),
+    [discoverArtifacts, discoverPath],
+  );
+
+  const contextGeneratedAt = contextPack?.generated_at
+    ? new Date(contextPack.generated_at).toLocaleString()
+    : null;
+  const contextJson = useMemo(
+    () => (contextPack ? JSON.stringify(contextPack, null, 2) : null),
+    [contextPack],
+  );
+  const contextFiles = useMemo(() => Object.keys(contextPack?.files ?? {}), [contextPack]);
+
+  const runDiscovery = useCallback(
+    async (payload: { owner: string; repo: string; branch: string; probeUrl?: string; project?: string }) => {
+      const discoverHeaders: HeadersInit = { "Content-Type": "application/json" };
+      if (resolvedSecrets.githubPat) {
+        discoverHeaders["x-github-pat"] = resolvedSecrets.githubPat;
+      }
+      const discoverResponse = await fetch("/api/discover", {
+        method: "POST",
+        headers: discoverHeaders,
+        body: JSON.stringify(payload),
+      });
+      const discoverJson = (await discoverResponse.json()) as DiscoverResponse;
+      setDiscoverArtifacts(discoverJson?.wrote ?? []);
+      setBacklog(discoverJson?.items ?? []);
+      setDiscoverConfig(discoverJson?.config ?? null);
+      setDbProbes(discoverJson?.db ?? []);
+      setCodeMatches(discoverJson?.code_matches ?? []);
+      const nowIso = new Date().toISOString();
+      setLastDiscoveryAt(nowIso);
+      if (!discoverResponse.ok || discoverJson?.ok === false || discoverJson?.error) {
+        throw new Error(discoverJson?.detail || discoverJson?.error || "Discover run failed");
+      }
+    },
+    [resolvedSecrets.githubPat],
+  );
+
+  const handleDiscoverOnly = useCallback(async () => {
+    if (!repoSlug) {
+      setError({
+        title: "Provide owner and repository",
+        detail: "Fill both fields before running discovery.",
+      });
+      return;
+    }
+
+    const payload = {
+      owner: owner.trim(),
+      repo: repo.trim(),
+      branch: branch.trim() || "main",
+      ...(probeUrl.trim() ? { probeUrl: probeUrl.trim() } : {}),
+      ...(projectKey ? { project: projectKey } : {}),
+    };
+
+    setIsDiscovering(true);
+    setError(null);
+    setDiscoverArtifacts([]);
+    setBacklog([]);
+    setDiscoverConfig(null);
+    setDbProbes([]);
+    setCodeMatches([]);
+    setLastDiscoveryAt(null);
+
+    try {
+      await runDiscovery(payload);
+    } catch (err: any) {
+      setError({
+        title: "Discovery failed",
+        detail: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      setIsDiscovering(false);
+    }
+  }, [branch, owner, probeUrl, projectKey, repo, repoSlug, runDiscovery]);
+
+  const handleExportContext = useCallback(async () => {
+    if (!repoSlug) {
+      setContextError({
+        title: "Provide owner and repository",
+        detail: "Fill the owner, repository, and branch before exporting a context pack.",
+      });
+      return;
+    }
+
+    const trimmedOwner = owner.trim();
+    const trimmedRepo = repo.trim();
+    const trimmedBranch = branchParam;
+
+    setContextError(null);
+    setContextPack(null);
+    setIsExporting(true);
+
+    try {
+      const contextHeaders: HeadersInit = { Accept: "application/json" };
+      if (resolvedSecrets.githubPat) {
+        contextHeaders["x-github-pat"] = resolvedSecrets.githubPat;
+      }
+      const projectQuery = projectKey ? `&project=${encodeURIComponent(projectKey)}` : "";
+      const response = await fetch(
+        `/api/context/${encodeURIComponent(trimmedOwner)}/${encodeURIComponent(trimmedRepo)}?branch=${encodeURIComponent(trimmedBranch)}${projectQuery}`,
+        { cache: "no-store", headers: contextHeaders },
+      );
+      const json = (await response.json()) as ContextPack & { error?: string; missing?: string[] };
+      if (!response.ok || json?.error) {
+        const missing = json?.missing?.length ? ` Missing files: ${json.missing.join(", ")}.` : "";
+        throw new Error(json?.error ? `${json.error}.${missing}` : `Failed to export context pack.${missing}`);
+      }
+      setContextPack(json);
+    } catch (err: any) {
+      setContextError({
+        title: "Export failed",
+        detail: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      setIsExporting(false);
+    }
+  }, [branchParam, owner, projectKey, repo, repoSlug, resolvedSecrets.githubPat]);
+
+  const handleDownloadContext = useCallback(() => {
+    if (!contextPack) return;
+    const filename = `${(repoSlug ?? "context-pack").replace(/\//g, "-")}.context-pack.json`;
+    const blob = new Blob([JSON.stringify(contextPack, null, 2)], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = filename;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  }, [contextPack, repoSlug]);
+
+  return (
+    <div className="tw-space-y-10">
+      <div>
+        <Link
+          href="/wizard/mid-build"
+          className="tw-inline-flex tw-items-center tw-gap-2 tw-rounded-full tw-border tw-border-slate-800 tw-bg-slate-950 tw-px-3 tw-py-1 tw-text-xs tw-font-medium tw-uppercase tw-tracking-wide tw-text-slate-300 hover:tw-border-slate-700 hover:tw-text-slate-100"
+        >
+          <span aria-hidden="true">←</span>
+          <span>Back to mid-project playbook</span>
+        </Link>
+      </div>
+
+      <header className="tw-space-y-3">
+        <span className="tw-inline-flex tw-items-center tw-gap-2 tw-rounded-full tw-border tw-border-slate-800 tw-px-3 tw-py-1 tw-text-xs tw-font-medium tw-uppercase tw-tracking-wide tw-text-slate-300">
+          Mid-project sync
+        </span>
+        <h1 className="tw-text-3xl tw-font-bold tw-leading-tight tw-text-slate-100">Refresh live project context</h1>
+        <p className="tw-text-base tw-leading-relaxed tw-text-slate-300">
+          Connect an active repository to regenerate roadmap status and discovery insights before diving into the full dashboard.
+        </p>
+        <div className="tw-flex tw-flex-wrap tw-gap-3 tw-text-xs tw-font-medium tw-uppercase tw-tracking-wide tw-text-slate-400">
+          <span>
+            {githubReady
+              ? `GitHub token ready (${githubSourceLabel ?? "global default"})`
+              : "Add a GitHub PAT in Settings"}
+          </span>
+          <span>
+            {supabaseReady
+              ? `Supabase probe ready (${supabaseSourceLabel ?? "global default"})`
+              : "Optional: add a Supabase probe in Settings"}
+          </span>
+        </div>
+      </header>
+
+      <form onSubmit={handleSync} className="tw-grid tw-gap-8 lg:tw-grid-cols-[1.4fr,1fr]">
+        <section className="tw-space-y-6 tw-rounded-3xl tw-border tw-border-slate-800 tw-bg-slate-900 tw-p-8">
+          <div className="tw-grid tw-gap-4 md:tw-grid-cols-2">
+            <label className="tw-flex tw-flex-col tw-gap-2 md:tw-col-span-2">
+              <span className="tw-text-sm tw-font-medium tw-text-slate-200">Linked repository</span>
+              <select
+                value={selectedRepoId}
+                onChange={handleRepoSelect}
+                className="tw-w-full tw-rounded-xl tw-border tw-border-slate-700 tw-bg-slate-950 tw-px-3 tw-py-2 tw-text-sm tw-text-slate-100 focus:tw-border-slate-500 focus:tw-outline-none"
+              >
+                <option value="">Manual entry</option>
+                {repoOptions.map((option) => {
+                  const label = option.displayName?.trim() || `${option.owner}/${option.repo}`;
+                  return (
+                    <option key={option.id} value={option.id}>
+                      {label}
+                    </option>
+                  );
+                })}
+              </select>
+            </label>
+            <label className="tw-flex tw-flex-col tw-gap-2">
+              <span className="tw-text-sm tw-font-medium tw-text-slate-200">Owner</span>
+              <input
+                value={owner}
+                onChange={(event) => setOwner(event.target.value)}
+                placeholder="acme-co"
+                className="tw-w-full tw-rounded-xl tw-border tw-border-slate-700 tw-bg-slate-950 tw-px-3 tw-py-2 tw-text-sm tw-text-slate-100 tw-placeholder-slate-500 focus:tw-border-slate-500 focus:tw-outline-none"
+              />
+            </label>
+            <label className="tw-flex tw-flex-col tw-gap-2">
+              <span className="tw-text-sm tw-font-medium tw-text-slate-200">Repository</span>
+              <input
+                value={repo}
+                onChange={(event) => setRepo(event.target.value)}
+                placeholder="product-app"
+                className="tw-w-full tw-rounded-xl tw-border tw-border-slate-700 tw-bg-slate-950 tw-px-3 tw-py-2 tw-text-sm tw-text-slate-100 tw-placeholder-slate-500 focus:tw-border-slate-500 focus:tw-outline-none"
+              />
+            </label>
+            {projectOptions.length ? (
+              <label className="tw-flex tw-flex-col tw-gap-2">
+                <span className="tw-text-sm tw-font-medium tw-text-slate-200">Project</span>
+                <select
+                  value={selectedProjectId}
+                  onChange={handleProjectSelect}
+                  className="tw-w-full tw-rounded-xl tw-border tw-border-slate-700 tw-bg-slate-950 tw-px-3 tw-py-2 tw-text-sm tw-text-slate-100 focus:tw-border-slate-500 focus:tw-outline-none"
+                >
+                  <option value="">Use repo defaults</option>
+                  {projectOptions.map((project) => (
+                    <option key={project.id} value={project.id}>
+                      {project.name}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            ) : null}
+            <label className="tw-flex tw-flex-col tw-gap-2">
+              <span className="tw-text-sm tw-font-medium tw-text-slate-200">Project slug (optional)</span>
+              <input
+                value={projectOverride}
+                onChange={(event) => setProjectOverride(event.target.value)}
+                placeholder={selectedProjectId || "growth-experiments"}
+                className="tw-w-full tw-rounded-xl tw-border tw-border-slate-700 tw-bg-slate-950 tw-px-3 tw-py-2 tw-text-sm tw-text-slate-100 tw-placeholder-slate-500 focus:tw-border-slate-500 focus:tw-outline-none"
+              />
+              <p className="tw-text-[11px] tw-text-slate-500">Roadmap file: {roadmapPath}</p>
+            </label>
+            <label className="tw-flex tw-flex-col tw-gap-2">
+              <span className="tw-text-sm tw-font-medium tw-text-slate-200">Branch</span>
+              <input
+                value={branch}
+                onChange={(event) => setBranch(event.target.value)}
+                placeholder="main"
+                className="tw-w-full tw-rounded-xl tw-border tw-border-slate-700 tw-bg-slate-950 tw-px-3 tw-py-2 tw-text-sm tw-text-slate-100 tw-placeholder-slate-500 focus:tw-border-slate-500 focus:tw-outline-none"
+              />
+            </label>
+            <label className="tw-flex tw-flex-col tw-gap-2">
+              <span className="tw-text-sm tw-font-medium tw-text-slate-200">Supabase probe URL (optional)</span>
+              <input
+                value={probeUrl}
+                onChange={handleProbeChange}
+                placeholder={resolvedSecrets.supabaseReadOnlyUrl ?? "https://.../rest/v1/rpc/roadmap_probe"}
+                className="tw-w-full tw-rounded-xl tw-border tw-border-slate-700 tw-bg-slate-950 tw-px-3 tw-py-2 tw-text-sm tw-text-slate-100 tw-placeholder-slate-500 focus:tw-border-slate-500 focus:tw-outline-none"
+              />
+              {resolvedSecrets.supabaseReadOnlyUrl ? (
+                <div className="tw-flex tw-items-center tw-justify-between tw-text-[11px] tw-text-slate-500">
+                  <span>Default from {supabaseSourceLabel ?? "settings"}</span>
+                  {probeCustomized ? (
+                    <button
+                      type="button"
+                      onClick={resetProbeToDefault}
+                      className="tw-text-[11px] tw-font-medium tw-text-slate-200 hover:tw-text-slate-100"
+                    >
+                      Use configured
+                    </button>
+                  ) : null}
+                </div>
+              ) : (
+                <span className="tw-text-[11px] tw-text-slate-500">
+                  Provide a checks endpoint or configure one in Settings.
+                </span>
+              )}
+            </label>
+          </div>
+
+          <div className="tw-flex tw-flex-wrap tw-items-center tw-justify-between tw-gap-4">
+            <div className="tw-text-sm tw-text-slate-400">
+              {statusGeneratedAt ? (
+                <span>Last synced {statusGeneratedAt}</span>
+              ) : (
+                <span>Run discovery to generate the latest status and backlog files.</span>
+              )}
+            </div>
+            <button
+              type="submit"
+              className="tw-inline-flex tw-items-center tw-gap-2 tw-rounded-full tw-bg-slate-100 tw-px-5 tw-py-2 tw-text-sm tw-font-semibold tw-text-slate-900 tw-transition tw-duration-200 tw-ease-out hover:tw-bg-slate-200 disabled:tw-cursor-not-allowed disabled:tw-bg-slate-700 disabled:tw-text-slate-400"
+              disabled={!canSubmit}
+            >
+              {isSyncing ? "Syncing…" : "Connect and sync"}
+            </button>
+          </div>
+
+          {error ? (
+            <div className="tw-rounded-2xl tw-border tw-border-red-500/40 tw-bg-red-500/10 tw-p-4 tw-text-sm tw-text-red-100">
+              <div className="tw-font-semibold">{error.title}</div>
+              {error.detail ? <div className="tw-text-red-100/80">{error.detail}</div> : null}
+            </div>
+          ) : null}
+        </section>
+
+        <aside className="tw-space-y-4 tw-rounded-3xl tw-border tw-border-slate-800 tw-bg-slate-900 tw-p-8">
+          <h2 className="tw-text-xl tw-font-semibold tw-text-slate-100">What this sync runs</h2>
+          <ul className="tw-space-y-3 tw-text-sm tw-text-slate-300 tw-list-disc tw-pl-5">
+            <li>
+              <span className="tw-font-medium tw-text-slate-100">/api/run</span> regenerates <code className="tw-rounded tw-bg-slate-950 tw-px-1 tw-py-0.5">{statusPath}</code> and <code className="tw-rounded tw-bg-slate-950 tw-px-1 tw-py-0.5">{projectPlanPath}</code>.
+            </li>
+            <li>
+              <span className="tw-font-medium tw-text-slate-100">/api/discover</span> looks for completed work outside the roadmap and updates <code className="tw-rounded tw-bg-slate-950 tw-px-1 tw-py-0.5">{backlogPath}</code>.
+            </li>
+            <li>Bring a Supabase probe URL to surface database checks along with code signals.</li>
+          </ul>
+          {dashboardHref ? (
+            <Link
+              href={dashboardHref}
+              className="tw-inline-flex tw-items-center tw-gap-2 tw-rounded-full tw-border tw-border-slate-700 tw-bg-slate-900 tw-px-4 tw-py-2 tw-text-sm tw-font-semibold tw-text-slate-200 tw-transition tw-duration-200 tw-ease-out hover:tw-border-slate-600 hover:tw-text-slate-100"
+            >
+              <span>Open {repoSlug} dashboard</span>
+              <span aria-hidden="true">↗</span>
+            </Link>
+          ) : null}
+        </aside>
+      </form>
+
+      <section className="tw-grid tw-gap-6 xl:tw-grid-cols-2">
+        <div
+          id="discover"
+          className="tw-space-y-4 tw-rounded-3xl tw-border tw-border-slate-800 tw-bg-slate-900 tw-p-8"
+        >
+          <div className="tw-flex tw-items-center tw-justify-between tw-gap-3">
+            <div>
+              <h2 className="tw-text-xl tw-font-semibold tw-text-slate-100">Roadmap status</h2>
+              <p className="tw-text-sm tw-text-slate-300">Snapshot of {statusPath} after the latest run.</p>
+            </div>
+            {statusGeneratedAt ? (
+              <span className="tw-rounded-full tw-border tw-border-slate-800 tw-bg-slate-950 tw-px-3 tw-py-1 tw-text-xs tw-font-medium tw-text-slate-400">
+                {statusGeneratedAt}
+              </span>
+            ) : null}
+          </div>
+          {status?.weeks?.length ? (
+            <StatusGrid status={status} />
+          ) : (
+            <div className="tw-rounded-2xl tw-border tw-border-slate-800 tw-bg-slate-950 tw-px-4 tw-py-8 tw-text-center tw-text-sm tw-text-slate-400">
+              Run the sync to populate the roadmap status grid.
+            </div>
+          )}
+        </div>
+
+        <div className="tw-space-y-4 tw-rounded-3xl tw-border tw-border-slate-800 tw-bg-slate-900 tw-p-8">
+          <div className="tw-flex tw-flex-wrap tw-items-center tw-justify-between tw-gap-3">
+            <div>
+              <h2 className="tw-text-xl tw-font-semibold tw-text-slate-100">Backlog discoveries</h2>
+              <p className="tw-text-sm tw-text-slate-300">Preview of {backlogPath} entries to triage.</p>
+            </div>
+            <div className="tw-flex tw-flex-wrap tw-items-center tw-gap-2">
+              {discoverArtifacts.length ? (
+                <span className="tw-rounded-full tw-border tw-border-slate-800 tw-bg-slate-950 tw-px-3 tw-py-1 tw-text-xs tw-font-medium tw-text-slate-400">
+                  {discoverArtifacts.length} files touched
+                </span>
+              ) : null}
+              {discoveryGeneratedAt ? (
+                <span className="tw-rounded-full tw-border tw-border-slate-800 tw-bg-slate-950 tw-px-3 tw-py-1 tw-text-xs tw-font-medium tw-text-slate-400">
+                  Discovery {discoveryGeneratedAt}
+                </span>
+              ) : null}
+              <button
+                type="button"
+                onClick={handleDiscoverOnly}
+                className="tw-inline-flex tw-items-center tw-gap-2 tw-rounded-full tw-border tw-border-slate-700 tw-bg-slate-900 tw-px-4 tw-py-2 tw-text-xs tw-font-semibold tw-text-slate-200 tw-transition tw-duration-200 tw-ease-out hover:tw-border-slate-600 hover:tw-text-slate-100 disabled:tw-cursor-not-allowed disabled:tw-border-slate-800 disabled:tw-text-slate-500"
+                disabled={!canDiscover}
+              >
+                {isDiscovering ? "Running…" : "Run discovery"}
+              </button>
+            </div>
+          </div>
+          {backlog.length ? (
+            <ul className="tw-space-y-3">
+              {backlog.map((item) => (
+                <li
+                  key={item.id}
+                  className="tw-flex tw-items-start tw-gap-3 tw-rounded-2xl tw-border tw-border-slate-800 tw-bg-slate-950 tw-p-4"
+                >
+                  <span className="tw-text-lg" aria-hidden="true">
+                    {item.status === "complete" ? "✅" : "•"}
+                  </span>
+                  <div className="tw-space-y-1">
+                    <p className="tw-text-sm tw-font-semibold tw-text-slate-100">{item.title}</p>
+                    <p className="tw-text-xs tw-uppercase tw-tracking-wide tw-text-slate-400">{item.id}</p>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <div className="tw-rounded-2xl tw-border tw-border-slate-800 tw-bg-slate-950 tw-px-4 tw-py-8 tw-text-center tw-text-sm tw-text-slate-400">
+              Use <span className="tw-font-semibold tw-text-slate-200">Run discovery</span> to surface completed work that never landed on the roadmap.
+            </div>
+          )}
+          {seededDiscover ? (
+            <div className="tw-rounded-2xl tw-border tw-border-emerald-500/40 tw-bg-emerald-500/10 tw-p-4 tw-text-xs tw-text-emerald-100">
+              <div className="tw-font-semibold">Default discovery config created</div>
+              <p className="tw-mt-1 tw-text-emerald-100/80">
+                We added <code className="tw-rounded tw-bg-emerald-500/20 tw-px-1 tw-py-0.5">{discoverPath}</code> to your repo with starter queries and globs. Update that file in GitHub to refine discovery results.
+              </p>
+            </div>
+          ) : null}
+        </div>
+
+        <div className="tw-space-y-4 tw-rounded-3xl tw-border tw-border-slate-800 tw-bg-slate-900 tw-p-8">
+          <div className="tw-flex tw-flex-wrap tw-items-center tw-justify-between tw-gap-2">
+            <h2 className="tw-text-xl tw-font-semibold tw-text-slate-100">Supabase probes</h2>
+            {discoveryGeneratedAt ? (
+              <span className="tw-rounded-full tw-border tw-border-slate-800 tw-bg-slate-950 tw-px-3 tw-py-1 tw-text-xs tw-font-medium tw-text-slate-400">
+                Discovery {discoveryGeneratedAt}
+              </span>
+            ) : null}
+          </div>
+          <p className="tw-text-sm tw-text-slate-300">
+            Results from <code className="tw-rounded tw-bg-slate-950 tw-px-1.5 tw-py-0.5">db_queries</code> in {discoverPath}.
+          </p>
+          {discoverConfig?.db_queries?.length ? (
+            <p className="tw-text-xs tw-uppercase tw-tracking-wide tw-text-slate-400">
+              {discoverConfig.db_queries.length} query{discoverConfig.db_queries.length === 1 ? "" : "ies"} configured
+            </p>
+          ) : null}
+          {dbProbes.length ? (
+            <ul className="tw-space-y-2">
+              {dbProbes.map((probe) => (
+                <li
+                  key={probe.q}
+                  className="tw-flex tw-items-start tw-gap-3 tw-rounded-2xl tw-border tw-border-slate-800 tw-bg-slate-950 tw-p-4"
+                >
+                  <span className="tw-text-lg" aria-hidden="true">
+                    {probe.ok ? "✅" : "⚠️"}
+                  </span>
+                  <div className="tw-space-y-1">
+                    <p className="tw-text-sm tw-font-semibold tw-text-slate-100">{probe.q}</p>
+                    <p className="tw-text-xs tw-uppercase tw-tracking-wide tw-text-slate-400">
+                      {probe.ok ? "Probe successful" : probe.why ? `Failed → ${probe.why}` : "Probe failed"}
+                    </p>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <div className="tw-rounded-2xl tw-border tw-border-slate-800 tw-bg-slate-950 tw-px-4 tw-py-8 tw-text-center tw-text-sm tw-text-slate-400">
+              Run discovery to execute Supabase probes defined in {discoverPath}.
+            </div>
+          )}
+          {discoverConfig?.notes?.length ? (
+            <div className="tw-rounded-2xl tw-border tw-border-slate-800 tw-bg-slate-950 tw-p-4 tw-text-xs tw-text-slate-300">
+              <div className="tw-font-semibold tw-text-slate-200">Notes</div>
+              <ul className="tw-mt-2 tw-space-y-1 tw-list-disc tw-pl-4">
+                {discoverConfig.notes.map((note) => (
+                  <li key={note}>{note}</li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+        </div>
+
+        <div className="tw-space-y-4 tw-rounded-3xl tw-border tw-border-slate-800 tw-bg-slate-900 tw-p-8">
+          <div className="tw-flex tw-flex-wrap tw-items-center tw-justify-between tw-gap-2">
+            <div>
+              <h2 className="tw-text-xl tw-font-semibold tw-text-slate-100">Code path matches</h2>
+              <p className="tw-text-sm tw-text-slate-300">
+                Globs from {discoverPath} matched against the repository tree.
+              </p>
+            </div>
+            {discoveryGeneratedAt ? (
+              <span className="tw-rounded-full tw-border tw-border-slate-800 tw-bg-slate-950 tw-px-3 tw-py-1 tw-text-xs tw-font-medium tw-text-slate-400">
+                Discovery {discoveryGeneratedAt}
+              </span>
+            ) : null}
+          </div>
+          {discoverConfig?.code_globs?.length ? (
+            <p className="tw-text-xs tw-uppercase tw-tracking-wide tw-text-slate-400">
+              {discoverConfig.code_globs.length} pattern{discoverConfig.code_globs.length === 1 ? "" : "s"} configured
+            </p>
+          ) : null}
+          {codeMatches.length ? (
+            <ul className="tw-space-y-2">
+              {codeMatches.map((path) => (
+                <li
+                  key={path}
+                  className="tw-rounded-2xl tw-border tw-border-slate-800 tw-bg-slate-950 tw-px-4 tw-py-2 tw-text-sm tw-text-slate-200"
+                >
+                  {path}
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <div className="tw-rounded-2xl tw-border tw-border-slate-800 tw-bg-slate-950 tw-px-4 tw-py-8 tw-text-center tw-text-sm tw-text-slate-400">
+              Run discovery to surface matched code paths from your repository.
+            </div>
+          )}
+        </div>
+
+        <div className="tw-space-y-4 tw-rounded-3xl tw-border tw-border-slate-800 tw-bg-slate-900 tw-p-8 xl:tw-col-span-2">
+          <h2 className="tw-text-xl tw-font-semibold tw-text-slate-100">Artifacts updated</h2>
+          <div className="tw-grid tw-gap-4 md:tw-grid-cols-2">
+            <div className="tw-space-y-2">
+              <h3 className="tw-text-sm tw-font-semibold tw-text-slate-200">Status run</h3>
+              {runArtifacts.length ? (
+                <ul className="tw-space-y-1 tw-text-sm tw-text-slate-300">
+                  {runArtifacts.map((path) => (
+                    <li key={path} className="tw-rounded-xl tw-border tw-border-slate-800 tw-bg-slate-950 tw-px-3 tw-py-2">
+                      {path}
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <p className="tw-text-sm tw-text-slate-400">Run the sync to regenerate roadmap artifacts.</p>
+              )}
+            </div>
+            <div className="tw-space-y-2">
+              <h3 className="tw-text-sm tw-font-semibold tw-text-slate-200">Discover run</h3>
+              {discoverArtifacts.length ? (
+                <ul className="tw-space-y-1 tw-text-sm tw-text-slate-300">
+                  {discoverArtifacts.map((path) => (
+                    <li key={path} className="tw-rounded-xl tw-border tw-border-slate-800 tw-bg-slate-950 tw-px-3 tw-py-2">
+                      {path}
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <p className="tw-text-sm tw-text-slate-400">Run discovery to surface backlog entries and summary docs.</p>
+              )}
+            </div>
+          </div>
+        </div>
+
+        <div
+          id="context-pack"
+          className="tw-space-y-4 tw-rounded-3xl tw-border tw-border-slate-800 tw-bg-slate-900 tw-p-8 xl:tw-col-span-2"
+        >
+          <div className="tw-flex tw-flex-col tw-gap-4 md:tw-flex-row md:tw-items-center md:tw-justify-between">
+            <div className="tw-space-y-1">
+              <h2 className="tw-text-xl tw-font-semibold tw-text-slate-100">Context pack export</h2>
+              <p className="tw-text-sm tw-text-slate-300">
+                Bundle {roadmapPath}, {statusPath}, {backlogPath}, {summaryPath}, and the supporting stack docs into a single JSON payload for AI copilots.
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={handleExportContext}
+              className="tw-inline-flex tw-items-center tw-gap-2 tw-rounded-full tw-bg-slate-100 tw-px-5 tw-py-2 tw-text-sm tw-font-semibold tw-text-slate-900 tw-transition tw-duration-200 tw-ease-out hover:tw-bg-slate-200 disabled:tw-cursor-not-allowed disabled:tw-bg-slate-700 disabled:tw-text-slate-400"
+              disabled={!repoSlug || isExporting}
+            >
+              {isExporting ? "Building context pack…" : "Generate context pack"}
+            </button>
+          </div>
+          {contextError ? (
+            <div className="tw-rounded-2xl tw-border tw-border-red-500/40 tw-bg-red-500/10 tw-p-4 tw-text-sm tw-text-red-100">
+              <div className="tw-font-semibold">{contextError.title}</div>
+              {contextError.detail ? <div className="tw-text-red-100/80">{contextError.detail}</div> : null}
+            </div>
+          ) : null}
+          {contextPack ? (
+            <div className="tw-space-y-4">
+              <div className="tw-flex tw-flex-wrap tw-items-center tw-gap-3">
+                {contextGeneratedAt ? (
+                  <span className="tw-rounded-full tw-border tw-border-slate-800 tw-bg-slate-950 tw-px-3 tw-py-1 tw-text-xs tw-font-medium tw-text-slate-400">
+                    Generated {contextGeneratedAt}
+                  </span>
+                ) : null}
+                {contextPack.repo?.project ? (
+                  <span className="tw-rounded-full tw-border tw-border-slate-800 tw-bg-slate-950 tw-px-3 tw-py-1 tw-text-xs tw-font-medium tw-text-slate-400">
+                    Project {contextPack.repo.project}
+                  </span>
+                ) : null}
+                {contextPack.repo?.branch ? (
+                  <span className="tw-rounded-full tw-border tw-border-slate-800 tw-bg-slate-950 tw-px-3 tw-py-1 tw-text-xs tw-font-medium tw-text-slate-400">
+                    Branch {contextPack.repo.branch}
+                  </span>
+                ) : null}
+                <button
+                  type="button"
+                  onClick={handleDownloadContext}
+                  className="tw-inline-flex tw-items-center tw-gap-2 tw-rounded-full tw-border tw-border-slate-700 tw-bg-slate-900 tw-px-4 tw-py-2 tw-text-sm tw-font-semibold tw-text-slate-200 tw-transition tw-duration-200 tw-ease-out hover:tw-border-slate-600 hover:tw-text-slate-100"
+                >
+                  Download JSON
+                </button>
+              </div>
+              {contextFiles.length ? (
+                <div className="tw-space-y-2">
+                  <h3 className="tw-text-sm tw-font-semibold tw-text-slate-200">Included files</h3>
+                  <ul className="tw-grid tw-gap-2 md:tw-grid-cols-2">
+                    {contextFiles.map((file) => (
+                      <li
+                        key={file}
+                        className="tw-rounded-xl tw-border tw-border-slate-800 tw-bg-slate-950 tw-px-3 tw-py-2 tw-text-sm tw-text-slate-300"
+                      >
+                        {file}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              ) : null}
+              {contextJson ? (
+                <details className="tw-rounded-2xl tw-border tw-border-slate-800 tw-bg-slate-950 tw-px-4 tw-py-3">
+                  <summary className="tw-cursor-pointer tw-text-sm tw-font-semibold tw-text-slate-200">
+                    View JSON payload
+                  </summary>
+                  <pre className="tw-mt-3 tw-max-h-96 tw-overflow-auto tw-rounded-xl tw-bg-slate-950 tw-p-4 tw-text-xs tw-leading-relaxed tw-text-slate-300">
+                    {contextJson}
+                  </pre>
+                </details>
+              ) : null}
+            </div>
+          ) : (
+            <p className="tw-text-sm tw-text-slate-400">
+              Generate a context pack to bundle the refreshed roadmap files for AI assistants or teammates.
+            </p>
+          )}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/wizard/page.tsx
+++ b/app/wizard/page.tsx
@@ -1,0 +1,80 @@
+import Link from "next/link";
+
+import { WIZARD_ENTRY_POINTS } from "@/lib/wizard-entry-points";
+
+export default function WizardLandingPage() {
+  return (
+    <section className="tw-space-y-10">
+      <div className="tw-space-y-3">
+        <span className="tw-inline-flex tw-items-center tw-gap-2 tw-rounded-full tw-border tw-border-slate-800 tw-px-3 tw-py-1 tw-text-xs tw-font-medium tw-uppercase tw-tracking-wide tw-text-slate-300">
+          Product Wizard
+        </span>
+        <h1 className="tw-text-3xl tw-font-bold tw-leading-tight tw-text-slate-100">
+          Choose your starting point
+        </h1>
+        <p className="tw-text-lg tw-leading-relaxed tw-text-slate-300">
+          Match the wizard to your current milestone so the right roadmap, automations, and integrations spin up instantly.
+        </p>
+      </div>
+
+      <div className="tw-grid tw-gap-6 md:tw-grid-cols-2">
+        {WIZARD_ENTRY_POINTS.map((entry) => (
+          <div
+            key={entry.slug}
+            className="tw-rounded-3xl tw-border tw-border-slate-800 tw-bg-slate-900 tw-p-8 tw-flex tw-flex-col tw-gap-6 tw-h-full tw-transition tw-duration-200 tw-ease-out tw-transform hover:tw-border-slate-700 hover:tw-shadow-xl hover:tw-translate-y-[-4px]"
+          >
+            <div className="tw-inline-flex tw-items-center tw-gap-2 tw-text-xs tw-font-semibold tw-uppercase tw-tracking-wide tw-text-slate-300">
+              <span className="tw-inline-flex tw-items-center tw-justify-center tw-rounded-full tw-border tw-border-slate-800 tw-px-3 tw-py-1 tw-text-[0.7rem] tw-font-semibold tw-text-slate-100">
+                {entry.label}
+              </span>
+              <span className="tw-text-slate-400">Entry Point</span>
+            </div>
+
+            <div className="tw-space-y-2">
+              <h2 className="tw-text-2xl tw-font-semibold tw-leading-snug tw-text-slate-100">
+                {entry.title}
+              </h2>
+              <p className="tw-text-sm tw-leading-relaxed tw-text-slate-300">{entry.description}</p>
+            </div>
+
+            <ul className="tw-space-y-2 tw-text-sm tw-text-slate-300 tw-list-disc tw-pl-5">
+              {entry.bullets.map((bullet) => (
+                <li key={bullet} className="tw-leading-relaxed">
+                  {bullet}
+                </li>
+              ))}
+            </ul>
+
+            <div className="tw-flex tw-flex-wrap tw-items-center tw-gap-3">
+              <Link
+                href={`/wizard/${entry.slug}`}
+                className="tw-inline-flex tw-items-center tw-gap-2 tw-rounded-full tw-bg-slate-100 tw-px-4 tw-py-2 tw-text-sm tw-font-semibold tw-text-slate-900 tw-transition tw-duration-200 tw-ease-out hover:tw-bg-slate-200"
+              >
+                <span>View playbook</span>
+                <span aria-hidden="true">→</span>
+              </Link>
+              {entry.tools?.map((tool) => (
+                <Link
+                  key={tool.href}
+                  href={tool.href}
+                  className="tw-inline-flex tw-items-center tw-gap-2 tw-rounded-full tw-border tw-border-slate-700 tw-bg-slate-900 tw-px-4 tw-py-2 tw-text-sm tw-font-semibold tw-text-slate-200 tw-transition tw-duration-200 tw-ease-out hover:tw-border-slate-600 hover:tw-text-slate-100"
+                >
+                  <span>{tool.label}</span>
+                  <span aria-hidden="true">↗</span>
+                </Link>
+              ))}
+            </div>
+
+            {entry.tools?.map((tool) =>
+              tool.description ? (
+                <p key={`${tool.href}-note`} className="tw-text-xs tw-leading-relaxed tw-text-slate-400">
+                  {tool.description}
+                </p>
+              ) : null
+            )}
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/app/wizard/roadmap/page.tsx
+++ b/app/wizard/roadmap/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function RoadmapWorkspaceRedirect() {
+  redirect("/wizard/roadmap/workspace");
+}

--- a/app/wizard/roadmap/workspace/page.tsx
+++ b/app/wizard/roadmap/workspace/page.tsx
@@ -1,0 +1,499 @@
+"use client";
+
+import {
+  ChangeEvent,
+  FormEvent,
+  Suspense,
+  useMemo,
+  useState,
+} from "react";
+import Link from "next/link";
+import { useSearchParams } from "next/navigation";
+import { load } from "js-yaml";
+
+import { describeProjectFile, normalizeProjectKey } from "@/lib/project-paths";
+import { useLocalSecrets, useResolvedSecrets } from "@/lib/use-local-secrets";
+
+type ErrorState = { title: string; detail?: string } | null;
+type SuccessState = {
+  created: string[];
+  skipped: string[];
+  owner: string;
+  repo: string;
+  branch?: string;
+  prUrl?: string;
+  pullRequestNumber?: number;
+  path?: string;
+} | null;
+
+type UploadState = {
+  name: string;
+  sizeLabel: string;
+};
+
+type ImportResponse = {
+  ok: boolean;
+  created?: string[];
+  skipped?: string[];
+  branch?: string;
+  prUrl?: string;
+  pullRequestNumber?: number;
+  error?: string;
+  detail?: string;
+};
+
+function formatBytes(bytes: number) {
+  if (Number.isNaN(bytes) || bytes <= 0) {
+    return "0 B";
+  }
+  const units = ["B", "KB", "MB", "GB"];
+  let value = bytes;
+  let unitIndex = 0;
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024;
+    unitIndex += 1;
+  }
+  const precision = value < 10 && unitIndex > 0 ? 1 : 0;
+  return `${value.toFixed(precision)} ${units[unitIndex]}`;
+}
+
+function RoadmapProvisionerInner() {
+  const params = useSearchParams();
+  const [owner, setOwner] = useState(() => params.get("owner") ?? "");
+  const [repo, setRepo] = useState(() => params.get("repo") ?? "");
+  const [branch, setBranch] = useState(() => params.get("branch") ?? "main");
+  const [project, setProject] = useState(() => params.get("project") ?? "");
+  const [upload, setUpload] = useState<UploadState | null>(null);
+  const [roadmap, setRoadmap] = useState("");
+  const [error, setError] = useState<ErrorState>(null);
+  const [success, setSuccess] = useState<SuccessState>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [uploadKey, setUploadKey] = useState(0);
+  const secretsStore = useLocalSecrets();
+  const secrets = useResolvedSecrets(owner, repo, project || undefined);
+  const githubConfigured = Boolean(secrets.githubPat);
+  const [openAsPr, setOpenAsPr] = useState(false);
+  const repoEntries = secretsStore.repos;
+  const repoSlug = useMemo(() => {
+    const ownerSlug = owner.trim().toLowerCase();
+    const repoSlugValue = repo.trim().toLowerCase();
+    return ownerSlug && repoSlugValue ? `${ownerSlug}/${repoSlugValue}` : "";
+  }, [owner, repo]);
+  const matchedRepoEntry = useMemo(() => {
+    if (!repoSlug) return undefined;
+    return repoEntries.find(
+      (entry) => `${entry.owner.toLowerCase()}/${entry.repo.toLowerCase()}` === repoSlug,
+    );
+  }, [repoEntries, repoSlug]);
+
+  const roadmapPreview = useMemo(() => roadmap.trim(), [roadmap]);
+  const hasRoadmap = Boolean(roadmapPreview);
+  const projectKey = useMemo(() => normalizeProjectKey(project), [project]);
+  const roadmapPath = describeProjectFile("docs/roadmap.yml", projectKey);
+  const infraPath = describeProjectFile("docs/infra-facts.md", projectKey);
+  const stackPath = describeProjectFile("docs/tech-stack.yml", projectKey);
+  const workflowPath = describeProjectFile(".github/workflows/roadmap.yml", projectKey);
+  const projectOptions = useMemo(() => matchedRepoEntry?.projects ?? [], [matchedRepoEntry]);
+  const activeProjectId = useMemo(() => {
+    if (!project) return "";
+    const matchById = projectOptions.find((option) => option.id === project);
+    if (matchById) return matchById.id;
+    const normalized = normalizeProjectKey(project);
+    const matchByKey = projectOptions.find((option) => normalizeProjectKey(option.id) === normalized);
+    return matchByKey?.id ?? project;
+  }, [project, projectOptions]);
+  const canSubmit = Boolean(!isSubmitting && owner && repo && branch && hasRoadmap);
+
+  async function handleFileChange(event: ChangeEvent<HTMLInputElement>) {
+    const file = event.target.files?.[0];
+    if (!file) {
+      setUpload(null);
+      setRoadmap("");
+      setSuccess(null);
+      setUploadKey((value) => value + 1);
+      return;
+    }
+
+    if (file.size > 2 * 1024 * 1024) {
+      setError({ title: "File too large", detail: "Limit uploads to 2MB roadmap files." });
+      event.target.value = "";
+      setUpload(null);
+      setRoadmap("");
+      setUploadKey((value) => value + 1);
+      return;
+    }
+
+    try {
+      const text = await file.text();
+      if (!text.trim()) {
+        throw new Error("Roadmap file is empty");
+      }
+      load(text);
+      setRoadmap(text.trimEnd());
+      setUpload({ name: file.name, sizeLabel: formatBytes(file.size) });
+      setError(null);
+      setSuccess(null);
+    } catch (err: any) {
+      setError({ title: "Invalid roadmap.yml", detail: err?.message ?? String(err) });
+      setUpload(null);
+      setRoadmap("");
+      setUploadKey((value) => value + 1);
+    }
+  }
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!canSubmit) {
+      setError({ title: "Provide required fields", detail: "Upload a roadmap and fill owner/repo before continuing." });
+      return;
+    }
+
+    setIsSubmitting(true);
+    setError(null);
+    setSuccess(null);
+
+    try {
+      const headers: HeadersInit = { "Content-Type": "application/json" };
+      if (secrets.githubPat) {
+        headers["x-github-pat"] = secrets.githubPat;
+      }
+
+      const endpoint = openAsPr ? "/api/roadmap/import?asPR=true" : "/api/roadmap/import";
+      const response = await fetch(endpoint, {
+        method: "POST",
+        headers,
+        body: JSON.stringify({ owner, repo, branch, roadmap, project: project || undefined }),
+      });
+
+      const payload = (await response.json().catch(() => ({}))) as ImportResponse;
+      if (!response.ok || !payload?.ok) {
+        const title = payload?.error ?? "Failed to import roadmap";
+        setError({ title, detail: payload?.detail });
+        return;
+      }
+
+      setSuccess({
+        created: payload.created ?? [],
+        skipped: payload.skipped ?? [],
+        owner,
+        repo,
+        branch: payload.branch ?? branch,
+        prUrl: payload.prUrl,
+        pullRequestNumber: payload.pullRequestNumber,
+      });
+    } catch (err: any) {
+      setError({ title: "Request failed", detail: err instanceof Error ? err.message : String(err) });
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  const projectQuery = projectKey ? `&project=${encodeURIComponent(projectKey)}` : "";
+  const dashboardHref = success && success.owner && success.repo
+    ? `/dashboard?owner=${encodeURIComponent(success.owner.trim())}&repo=${encodeURIComponent(success.repo.trim())}${projectQuery}`
+    : null;
+
+  return (
+    <div className="tw-space-y-10">
+      <header className="tw-space-y-3">
+        <span className="tw-inline-flex tw-items-center tw-gap-2 tw-rounded-full tw-border tw-border-slate-800 tw-px-3 tw-py-1 tw-text-xs tw-font-medium tw-uppercase tw-tracking-wide tw-text-slate-300">
+          Roadmap provisioning
+        </span>
+        <h1 className="tw-text-3xl tw-font-bold tw-leading-tight tw-text-slate-100">
+          Import roadmap.yml and scaffold automations
+        </h1>
+        <p className="tw-text-base tw-leading-relaxed tw-text-slate-300">
+          Upload your finalized roadmap to sync docs/roadmap.yml, then generate the foundational artifacts that power status checks and team context.
+        </p>
+        <p className="tw-text-xs tw-font-medium tw-uppercase tw-tracking-wide tw-text-slate-400">
+          {githubConfigured ? "GitHub token ready" : "Add a GitHub PAT in Settings to allow commits"}
+        </p>
+      </header>
+
+      <form onSubmit={handleSubmit} className="tw-grid tw-gap-8 lg:tw-grid-cols-[2fr,1fr]">
+        <section className="tw-space-y-6 tw-rounded-3xl tw-border tw-border-slate-800 tw-bg-slate-900 tw-p-8">
+          <div className="tw-grid tw-gap-4 md:tw-grid-cols-3">
+            <label className="tw-flex tw-flex-col tw-gap-2">
+              <span className="tw-text-sm tw-font-medium tw-text-slate-200">Owner</span>
+              <input
+                value={owner}
+                onChange={(event) => setOwner(event.target.value)}
+                placeholder="acme-co"
+                className="tw-w-full tw-rounded-xl tw-border tw-border-slate-700 tw-bg-slate-950 tw-px-3 tw-py-2 tw-text-sm tw-text-slate-100 tw-placeholder-slate-500 focus:tw-border-slate-500 focus:tw-outline-none"
+              />
+            </label>
+            <label className="tw-flex tw-flex-col tw-gap-2">
+              <span className="tw-text-sm tw-font-medium tw-text-slate-200">Repository</span>
+              <input
+                value={repo}
+                onChange={(event) => setRepo(event.target.value)}
+                placeholder="product-app"
+                className="tw-w-full tw-rounded-xl tw-border tw-border-slate-700 tw-bg-slate-950 tw-px-3 tw-py-2 tw-text-sm tw-text-slate-100 tw-placeholder-slate-500 focus:tw-border-slate-500 focus:tw-outline-none"
+              />
+            </label>
+            <label className="tw-flex tw-flex-col tw-gap-2">
+              <span className="tw-text-sm tw-font-medium tw-text-slate-200">Branch</span>
+              <input
+                value={branch}
+                onChange={(event) => setBranch(event.target.value)}
+                placeholder="main"
+                className="tw-w-full tw-rounded-xl tw-border tw-border-slate-700 tw-bg-slate-950 tw-px-3 tw-py-2 tw-text-sm tw-text-slate-100 tw-placeholder-slate-500 focus:tw-border-slate-500 focus:tw-outline-none"
+              />
+            </label>
+            <label className="tw-flex tw-flex-col tw-gap-2">
+              <span className="tw-text-sm tw-font-medium tw-text-slate-200">Project (optional)</span>
+              <input
+                value={project}
+                onChange={(event) => setProject(event.target.value)}
+                placeholder="growth-experiments"
+                className="tw-w-full tw-rounded-xl tw-border tw-border-slate-700 tw-bg-slate-950 tw-px-3 tw-py-2 tw-text-sm tw-text-slate-100 tw-placeholder-slate-500 focus:tw-border-slate-500 focus:tw-outline-none"
+              />
+            </label>
+          </div>
+
+          {repoEntries.length > 0 && (
+            <div className="tw-rounded-2xl tw-border tw-border-slate-800 tw-bg-slate-950/60 tw-p-4 tw-space-y-3">
+              <div className="tw-flex tw-flex-wrap tw-items-center tw-justify-between tw-gap-3">
+                <h3 className="tw-text-sm tw-font-semibold tw-text-slate-200">Linked repositories</h3>
+                <p className="tw-text-xs tw-text-slate-400">Pick a repo to auto-fill owner, branch, and project details.</p>
+              </div>
+              <div className="tw-flex tw-flex-wrap tw-gap-2">
+                {repoEntries.map((entry) => {
+                  const label = entry.displayName?.trim() || `${entry.owner}/${entry.repo}`;
+                  const entrySlug = `${entry.owner.toLowerCase()}/${entry.repo.toLowerCase()}`;
+                  const isActive = repoSlug === entrySlug;
+                  return (
+                    <button
+                      key={entry.id}
+                      type="button"
+                      onClick={() => {
+                        setOwner(entry.owner);
+                        setRepo(entry.repo);
+                        if (entry.projects.length === 1) {
+                          setProject(entry.projects[0].id);
+                        }
+                      }}
+                      className={`tw-inline-flex tw-items-center tw-gap-2 tw-rounded-full tw-border tw-px-3 tw-py-1.5 tw-text-xs tw-font-semibold tw-transition tw-duration-200 tw-ease-out ${
+                        isActive
+                          ? "tw-border-emerald-500 tw-bg-emerald-600/10 tw-text-emerald-200"
+                          : "tw-border-slate-700 tw-bg-slate-900 tw-text-slate-200 hover:tw-border-slate-600"
+                      }`}
+                    >
+                      {label}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+
+          {projectOptions.length > 0 && (
+            <div className="tw-space-y-3 tw-rounded-2xl tw-border tw-border-slate-800 tw-bg-slate-950/60 tw-p-4">
+              <div className="tw-flex tw-flex-wrap tw-items-center tw-justify-between tw-gap-3">
+                <h3 className="tw-text-sm tw-font-semibold tw-text-slate-200">Projects in {matchedRepoEntry?.displayName ?? `${owner || "repo"}`}</h3>
+                <p className="tw-text-xs tw-text-slate-400">Select a saved project or continue typing a new one above.</p>
+              </div>
+              <div className="tw-flex tw-flex-wrap tw-gap-2">
+                {projectOptions.map((option) => {
+                  const isActive = activeProjectId === option.id || project === option.id;
+                  return (
+                    <button
+                      key={option.id}
+                      type="button"
+                      onClick={() => setProject(option.id)}
+                      className={`tw-inline-flex tw-items-center tw-gap-2 tw-rounded-full tw-border tw-px-3 tw-py-1.5 tw-text-xs tw-font-semibold tw-transition tw-duration-200 tw-ease-out ${
+                        isActive
+                          ? "tw-border-emerald-500 tw-bg-emerald-600/10 tw-text-emerald-200"
+                          : "tw-border-slate-700 tw-bg-slate-900 tw-text-slate-200 hover:tw-border-slate-600"
+                      }`}
+                    >
+                      {option.name}
+                    </button>
+                  );
+                })}
+              </div>
+              <p className="tw-text-xs tw-text-slate-400">
+                Target files include <code className="tw-font-mono tw-text-[11px]">{roadmapPath}</code>, <code className="tw-font-mono tw-text-[11px]">{infraPath}</code>,
+                and <code className="tw-font-mono tw-text-[11px]">{stackPath}</code>.
+              </p>
+            </div>
+          )}
+
+          <div className="tw-space-y-3">
+            <label htmlFor="roadmap-upload" className="tw-block tw-text-sm tw-font-medium tw-text-slate-200">
+              Upload {roadmapPath}
+            </label>
+            <input
+              key={uploadKey}
+              id="roadmap-upload"
+              type="file"
+              accept=".yml,.yaml"
+              onChange={handleFileChange}
+              className="tw-w-full tw-rounded-xl tw-border tw-border-dashed tw-border-slate-700 tw-bg-slate-950 tw-px-3 tw-py-3 tw-text-sm tw-text-slate-300 focus:tw-border-slate-500 focus:tw-outline-none"
+            />
+            {upload ? (
+              <div className="tw-flex tw-items-center tw-justify-between tw-rounded-xl tw-border tw-border-slate-800 tw-bg-slate-950 tw-px-4 tw-py-3">
+                <div>
+                  <p className="tw-text-sm tw-font-medium tw-text-slate-100">{upload.name}</p>
+                  <p className="tw-text-xs tw-text-slate-400">{upload.sizeLabel}</p>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setUpload(null);
+                    setRoadmap("");
+                    setSuccess(null);
+                    setUploadKey((value) => value + 1);
+                  }}
+                  className="tw-text-xs tw-font-semibold tw-text-slate-300 hover:tw-text-slate-100"
+                >
+                  Remove
+                </button>
+              </div>
+            ) : (
+              <p className="tw-text-xs tw-text-slate-400">
+                Accepts .yml or .yaml files up to 2MB. We validate the file with js-yaml before committing it to your repository.
+              </p>
+            )}
+          </div>
+
+          {hasRoadmap ? (
+            <div className="tw-space-y-2">
+              <div className="tw-flex tw-items-center tw-justify-between">
+                <h2 className="tw-text-base tw-font-semibold tw-text-slate-200">Preview</h2>
+                <span className="tw-text-xs tw-font-medium tw-text-emerald-400">Validated ✓</span>
+              </div>
+              <pre className="tw-max-h-72 tw-overflow-auto tw-rounded-2xl tw-border tw-border-slate-800 tw-bg-slate-950 tw-p-4 tw-text-xs tw-leading-relaxed tw-text-slate-200">
+                <code>{roadmapPreview}</code>
+              </pre>
+            </div>
+          ) : null}
+
+          {error ? (
+            <div className="tw-rounded-2xl tw-border tw-border-rose-800 tw-bg-rose-950/40 tw-p-4">
+              <h3 className="tw-text-sm tw-font-semibold tw-text-rose-200">{error.title}</h3>
+              {error.detail ? <p className="tw-text-xs tw-text-rose-300 tw-mt-1">{error.detail}</p> : null}
+            </div>
+          ) : null}
+
+          {success ? (
+            <div className="tw-rounded-2xl tw-border tw-border-emerald-700 tw-bg-emerald-950/40 tw-p-4 tw-space-y-3">
+              <div>
+                <h3 className="tw-text-sm tw-font-semibold tw-text-emerald-200">Roadmap imported successfully</h3>
+                <p className="tw-text-xs tw-text-emerald-100">
+                  Created {success.created.length} files
+                  {success.skipped.length ? `, skipped ${success.skipped.length} existing` : ""}.
+                </p>
+                {success.branch ? (
+                  <p className="tw-mt-1 tw-text-xs tw-text-emerald-200/80">
+                    Changes pushed to <code className="tw-font-mono tw-text-[11px]">{success.branch}</code>.
+                  </p>
+                ) : null}
+              </div>
+              {success.prUrl ? (
+                <a
+                  href={success.prUrl}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="tw-inline-flex tw-items-center tw-gap-2 tw-rounded-full tw-border tw-border-emerald-500 tw-bg-emerald-600/10 tw-px-3 tw-py-1.5 tw-text-xs tw-font-semibold tw-text-emerald-100 hover:tw-bg-emerald-600/20"
+                >
+                  View {success.pullRequestNumber ? `PR #${success.pullRequestNumber}` : "pull request"}
+                  <span aria-hidden="true">↗</span>
+                </a>
+              ) : null}
+              {dashboardHref ? (
+                <Link
+                  href={dashboardHref}
+                  className="tw-inline-flex tw-items-center tw-gap-2 tw-rounded-full tw-border tw-border-emerald-500 tw-bg-emerald-600/10 tw-px-3 tw-py-1.5 tw-text-xs tw-font-semibold tw-text-emerald-100 hover:tw-bg-emerald-600/20"
+                >
+                  View dashboard
+                  <span aria-hidden="true">↗</span>
+                </Link>
+              ) : null}
+            </div>
+          ) : null}
+
+          <div className="tw-flex tw-flex-wrap tw-items-center tw-gap-3">
+            <button
+              type="submit"
+              disabled={!canSubmit}
+              className="tw-inline-flex tw-items-center tw-justify-center tw-rounded-full tw-bg-slate-100 tw-px-5 tw-py-2.5 tw-text-sm tw-font-semibold tw-text-slate-900 tw-transition tw-duration-200 tw-ease-out disabled:tw-cursor-not-allowed disabled:tw-bg-slate-500/50"
+            >
+              {isSubmitting ? "Importing…" : "Import & scaffold"}
+            </button>
+            <label className="tw-inline-flex tw-items-center tw-gap-2 tw-rounded-full tw-border tw-border-slate-800 tw-bg-slate-950/60 tw-px-3 tw-py-1.5 tw-text-xs tw-font-medium tw-text-slate-200">
+              <input
+                type="checkbox"
+                checked={openAsPr}
+                onChange={(event) => setOpenAsPr(event.target.checked)}
+                className="tw-h-3.5 tw-w-3.5 tw-rounded tw-border tw-border-slate-700 tw-bg-slate-900 tw-text-emerald-400 focus:tw-ring-emerald-400"
+              />
+              <span>Open as pull request</span>
+            </label>
+            <p className="tw-text-xs tw-text-slate-400">
+              {openAsPr
+                ? "Creates a new branch and opens a PR with the roadmap scaffolding."
+                : `Commits docs/roadmap.yml and scaffolding directly to ${success?.branch ?? branch}.`}
+            </p>
+          </div>
+        </section>
+
+        <aside className="tw-space-y-6 tw-rounded-3xl tw-border tw-border-slate-800 tw-bg-slate-950 tw-p-8">
+          <div className="tw-space-y-2">
+            <h2 className="tw-text-lg tw-font-semibold tw-text-slate-100">What gets created</h2>
+            <p className="tw-text-sm tw-text-slate-300">
+              In addition to syncing docs/roadmap.yml, we provision supporting files that keep your roadmap connected to infra, tech stack, and automation workflows.
+            </p>
+          </div>
+          <ul className="tw-space-y-4">
+            <li className="tw-rounded-2xl tw-border tw-border-slate-800 tw-bg-slate-900 tw-p-4">
+              <h3 className="tw-text-sm tw-font-semibold tw-text-slate-100">docs/infra-facts.md</h3>
+              <p className="tw-text-xs tw-text-slate-300">
+                Capture deployment constraints, database configuration, and escalation paths so handoffs stay smooth once build work begins.
+              </p>
+            </li>
+            <li className="tw-rounded-2xl tw-border tw-border-slate-800 tw-bg-slate-900 tw-p-4">
+              <h3 className="tw-text-sm tw-font-semibold tw-text-slate-100">docs/tech-stack.yml</h3>
+              <p className="tw-text-xs tw-text-slate-300">
+                Fill in frameworks, services, and integrations to give AI copilots and collaborators a consistent view of your stack.
+              </p>
+            </li>
+            <li className="tw-rounded-2xl tw-border tw-border-slate-800 tw-bg-slate-900 tw-p-4">
+              <h3 className="tw-text-sm tw-font-semibold tw-text-slate-100">.github/workflows/roadmap.yml</h3>
+              <p className="tw-text-xs tw-text-slate-300">
+                Runs roadmap checks on pushes and pull requests, wiring status updates into the dashboard.
+              </p>
+            </li>
+          </ul>
+          <div className="tw-rounded-2xl tw-border tw-border-slate-800 tw-bg-slate-900 tw-p-4 tw-space-y-2">
+            <h3 className="tw-text-sm tw-font-semibold tw-text-slate-100">Need the dashboard link?</h3>
+            <p className="tw-text-xs tw-text-slate-300">
+              After import, jump straight to the live dashboard for this repository to confirm status feeds and roadmap context are flowing.
+            </p>
+            {dashboardHref ? (
+              <Link
+                href={dashboardHref}
+                className="tw-inline-flex tw-items-center tw-gap-2 tw-rounded-full tw-border tw-border-slate-700 tw-bg-slate-900 tw-px-3 tw-py-1.5 tw-text-xs tw-font-semibold tw-text-slate-200 hover:tw-border-slate-500"
+              >
+                Open {success?.owner}/{success?.repo}
+                <span aria-hidden="true">↗</span>
+              </Link>
+            ) : (
+              <p className="tw-text-xs tw-text-slate-500">Link will appear after a successful import.</p>
+            )}
+          </div>
+        </aside>
+      </form>
+    </div>
+  );
+}
+
+function RoadmapProvisionerPage() {
+  return (
+    <Suspense fallback={<div className="tw-text-slate-300">Loading roadmap wizard…</div>}>
+      <RoadmapProvisionerInner />
+    </Suspense>
+  );
+}
+
+export default RoadmapProvisionerPage;

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -44,35 +44,65 @@ export async function getFileRaw(owner: string, repo: string, path: string, ref?
   return r.text();
 }
 
-export async function putFile(
+export interface PutFileOptions {
+  token?: string;
+  asPR?: boolean;
+  prTitle?: string;
+  prBody?: string;
+  headBranch?: string;
+}
+
+export interface PutFileResult {
+  branch: string;
+  pullRequest?: {
+    number?: number;
+    url?: string;
+    html_url?: string;
+  };
+  [key: string]: unknown;
+}
+
+function encodeGitRef(ref: string) {
+  return ref
+    .split("/")
+    .map((part) => encodeURIComponent(part))
+    .join("/");
+}
+
+function generateRoadmapBranch(baseBranch: string) {
+  const sanitizedBase = baseBranch
+    .toLowerCase()
+    .replace(/[^a-z0-9-]/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+  const suffix = Date.now().toString(36);
+  return `${sanitizedBase ? `${sanitizedBase}-` : ""}roadmap-${suffix}`;
+}
+
+async function commitToBranch(
   owner: string,
   repo: string,
   path: string,
   content: string,
   branch: string,
   message: string,
-  token?: string
-) {
-  const t = token || (await ghToken());
+  token: string,
+): Promise<Record<string, unknown>> {
   const encodedPath = encodeGitHubPath(path);
-
-  // 1) Fetch current sha (JSON accept!)
   const metaUrl = `https://api.github.com/repos/${owner}/${repo}/contents/${encodedPath}?ref=${encodeURIComponent(branch)}`;
   let sha: string | undefined = undefined;
   {
-    const meta = await fetch(metaUrl, { headers: ghHeaders(t, "json") });
+    const meta = await fetch(metaUrl, { headers: ghHeaders(token, "json") });
     if (meta.status === 401) throw new Error(`GitHub 401 on HEAD (check PAT scope/access for ${owner}/${repo})`);
     if (meta.status === 200) {
       const j = (await meta.json()) as { sha?: string };
       if (typeof j?.sha === "string") sha = j.sha;
     } else if (meta.status !== 404) {
-      // Non-404, non-200 should surface (e.g., 403 on private repo)
       const txt = await meta.text();
       throw new Error(`HEAD ${owner}/${repo}:${path} failed: ${meta.status} ${txt}`);
     }
   }
 
-  // 2) PUT create-or-update with sha when present
   const putUrl = `https://api.github.com/repos/${owner}/${repo}/contents/${encodedPath}`;
   const body = JSON.stringify({
     message,
@@ -83,21 +113,19 @@ export async function putFile(
 
   const r = await fetch(putUrl, {
     method: "PUT",
-    headers: ghHeaders(t, "json"),
+    headers: ghHeaders(token, "json"),
     body,
   });
 
-  // 3) Helpful errors & a small retry on 409 (branch race)
   if (r.status === 409) {
-    // optional: one light retry after re-fetching sha
-    const meta2 = await fetch(metaUrl, { headers: ghHeaders(t, "json") });
+    const meta2 = await fetch(metaUrl, { headers: ghHeaders(token, "json") });
     if (meta2.ok) {
       const j2 = (await meta2.json()) as { sha?: string };
       const sha2 = j2?.sha;
       if (sha2) {
         const r2 = await fetch(putUrl, {
           method: "PUT",
-          headers: ghHeaders(t, "json"),
+          headers: ghHeaders(token, "json"),
           body: JSON.stringify({
             message,
             branch,
@@ -106,7 +134,7 @@ export async function putFile(
           }),
         });
         if (!r2.ok) throw new Error(`PUT retry ${owner}/${repo}:${path} failed: ${r2.status} ${await r2.text()}`);
-        return r2.json();
+        return r2.json() as Promise<Record<string, unknown>>;
       }
     }
     throw new Error(`PUT ${owner}/${repo}:${path} conflict (branch update required)`);
@@ -114,7 +142,6 @@ export async function putFile(
 
   if (r.status === 401) throw new Error(`GitHub 401 on PUT (check PAT scope/access for ${owner}/${repo})`);
   if (r.status === 422) {
-    // Typically "sha wasn't supplied" or "sha does not match"
     const txt = await r.text();
     throw new Error(`PUT ${owner}/${repo}:${path} failed 422 (likely missing/old sha): ${txt}`);
   }
@@ -123,6 +150,143 @@ export async function putFile(
     throw new Error(`PUT ${owner}/${repo}:${path} failed: ${r.status} ${txt}`);
   }
 
-  return r.json();
+  return r.json() as Promise<Record<string, unknown>>;
 }
+
+async function createPullRequest(
+  owner: string,
+  repo: string,
+  headBranch: string,
+  baseBranch: string,
+  message: string,
+  token: string,
+  body?: string,
+) {
+  const prUrl = `https://api.github.com/repos/${owner}/${repo}/pulls`;
+  const prResponse = await fetch(prUrl, {
+    method: "POST",
+    headers: ghHeaders(token, "json"),
+    body: JSON.stringify({
+      title: message,
+      head: headBranch,
+      base: baseBranch,
+      body: body ?? "",
+    }),
+  });
+
+  if (!prResponse.ok) {
+    const txt = await prResponse.text();
+    throw new Error(`Failed to open pull request (${prResponse.status}): ${txt}`);
+  }
+
+  return (await prResponse.json()) as { number?: number; url?: string; html_url?: string };
+}
+
+export async function putFile(
+  owner: string,
+  repo: string,
+  path: string,
+  content: string,
+  branch: string,
+  message: string,
+  tokenOrOptions?: string | PutFileOptions,
+  maybeOptions?: PutFileOptions,
+): Promise<PutFileResult> {
+  let options: PutFileOptions = {};
+  if (typeof tokenOrOptions === "string" || typeof tokenOrOptions === "undefined") {
+    options = { ...(maybeOptions ?? {}), token: tokenOrOptions };
+  } else if (tokenOrOptions) {
+    options = { ...tokenOrOptions };
+  }
+
+  const t = options.token ?? (await ghToken());
+  const asPR = Boolean(options.asPR);
+
+  if (!asPR) {
+    const result = await commitToBranch(owner, repo, path, content, branch, message, t);
+    return { ...result, branch };
+  }
+
+  const baseBranch = branch || "main";
+  const headBranch = options.headBranch?.trim() || generateRoadmapBranch(baseBranch);
+
+  const refUrl = `https://api.github.com/repos/${owner}/${repo}/git/ref/heads/${encodeGitRef(baseBranch)}`;
+  const baseRefResponse = await fetch(refUrl, { headers: ghHeaders(t, "json") });
+  if (baseRefResponse.status === 404) {
+    throw new Error(`Base branch ${baseBranch} not found in ${owner}/${repo}`);
+  }
+  if (!baseRefResponse.ok) {
+    const txt = await baseRefResponse.text();
+    throw new Error(`Failed to load base branch ${baseBranch}: ${baseRefResponse.status} ${txt}`);
+  }
+
+  const baseRef = (await baseRefResponse.json()) as { object?: { sha?: string } };
+  const baseSha = baseRef?.object?.sha;
+  if (!baseSha) {
+    throw new Error(`Unable to resolve sha for ${owner}/${repo}@${baseBranch}`);
+  }
+
+  let branchToUse = headBranch;
+  const createRefUrl = `https://api.github.com/repos/${owner}/${repo}/git/refs`;
+
+  async function tryCreateRef(targetBranch: string, allowRetry: boolean): Promise<string> {
+    const createResponse = await fetch(createRefUrl, {
+      method: "POST",
+      headers: ghHeaders(t, "json"),
+      body: JSON.stringify({ ref: `refs/heads/${targetBranch}`, sha: baseSha }),
+    });
+
+    if (createResponse.ok) {
+      return targetBranch;
+    }
+
+    if (createResponse.status === 422 && allowRetry) {
+      const fallback = `${targetBranch}-${Math.random().toString(36).slice(2, 8)}`;
+      return tryCreateRef(fallback, false);
+    }
+
+    const txt = await createResponse.text();
+    throw new Error(`Failed to create branch ${targetBranch}: ${createResponse.status} ${txt}`);
+  }
+
+  branchToUse = await tryCreateRef(branchToUse, !options.headBranch);
+
+  const commitResult = await commitToBranch(owner, repo, path, content, branchToUse, message, t);
+  const prTitle = options.prTitle?.trim() || message;
+  const prBody = options.prBody;
+  const pullRequest = await createPullRequest(owner, repo, branchToUse, baseBranch, prTitle, t, prBody);
+
+  return { ...commitResult, branch: branchToUse, pullRequest };
+}
+
+export async function listRepoTreePaths(
+  owner: string,
+  repo: string,
+  ref = "HEAD",
+  token?: string
+) {
+  const t = token ?? (await ghToken(false));
+  const url =
+    `https://api.github.com/repos/${owner}/${repo}/git/trees/${encodeURIComponent(ref)}` +
+    "?recursive=1";
+  const r = await fetch(url, { headers: ghHeaders(t, "json"), cache: "no-store" });
+  if (r.status === 404) return [] as string[];
+  if (r.status === 401) {
+    if (!t) throw new Error(`GitHub 401 (set GITHUB_TOKEN with access to ${owner}/${repo})`);
+    throw new Error(`GitHub 401 (check PAT scope/access for ${owner}/${repo})`);
+  }
+  if (!r.ok) {
+    const txt = await r.text();
+    throw new Error(`GET tree ${owner}/${repo}@${ref} failed: ${r.status} ${txt}`);
+  }
+
+  const json = (await r.json()) as { tree?: Array<{ type?: string; path?: string }> };
+  if (!json?.tree) return [] as string[];
+  return json.tree
+    .filter((node) => node?.type === "blob" && typeof node?.path === "string")
+    .map((node) => node.path!)
+    .sort();
+}
+
+export const listRepoTree = listRepoTreePaths;
 

--- a/lib/project-paths.ts
+++ b/lib/project-paths.ts
@@ -1,0 +1,37 @@
+export function normalizeProjectKey(input?: string | null): string | undefined {
+  if (typeof input !== "string") return undefined;
+  const trimmed = input.trim().toLowerCase();
+  if (!trimmed) return undefined;
+  const normalized = trimmed
+    .replace(/[^a-z0-9-]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 64);
+  return normalized || undefined;
+}
+
+export function projectAwarePath(path: string, projectKey?: string | null): string {
+  const key = normalizeProjectKey(projectKey);
+  if (!key) return path;
+  if (path.startsWith("docs/")) {
+    const remainder = path.slice("docs/".length);
+    return `docs/projects/${key}/${remainder}`;
+  }
+  if (path === ".github/workflows/roadmap.yml") {
+    return `.github/workflows/roadmap-${key}.yml`;
+  }
+  return path;
+}
+
+export function describeProjectFile(path: string, projectKey?: string | null): string {
+  const key = normalizeProjectKey(projectKey);
+  if (!key) return path;
+  if (path.startsWith("docs/")) {
+    const remainder = path.slice("docs/".length);
+    return `docs/projects/${key}/${remainder}`;
+  }
+  if (path === ".github/workflows/roadmap.yml") {
+    return `.github/workflows/roadmap-${key}.yml`;
+  }
+  return path;
+}

--- a/lib/use-local-secrets.ts
+++ b/lib/use-local-secrets.ts
@@ -1,0 +1,365 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+export type RepoProjectSecrets = {
+  id: string;
+  name: string;
+  supabaseReadOnlyUrl?: string;
+  githubPat?: string;
+  openaiKey?: string;
+};
+
+export type RepoSecrets = {
+  id: string;
+  owner: string;
+  repo: string;
+  displayName?: string;
+  supabaseReadOnlyUrl?: string;
+  githubPat?: string;
+  openaiKey?: string;
+  projects: RepoProjectSecrets[];
+};
+
+export type SecretsStore = {
+  defaults: {
+    githubPat?: string;
+    openaiKey?: string;
+    supabaseReadOnlyUrl?: string;
+  };
+  repos: RepoSecrets[];
+};
+
+export type ResolvedSecrets = {
+  githubPat?: string;
+  openaiKey?: string;
+  supabaseReadOnlyUrl?: string;
+  sources: {
+    githubPat?: "project" | "repo" | "default";
+    openaiKey?: "project" | "repo" | "default";
+    supabaseReadOnlyUrl?: "project" | "repo" | "default";
+  };
+  repo?: RepoSecrets;
+  project?: RepoProjectSecrets;
+};
+
+export const LOCAL_SECRETS_STORAGE_KEY = "rdp.settings.secrets";
+export const LOCAL_SECRETS_EVENT = "rdp:secrets-updated";
+
+const EMPTY_STORE: SecretsStore = {
+  defaults: {},
+  repos: [],
+};
+
+function sanitizeString(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function slugify(value: string) {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 48) || "project";
+}
+
+function randomId(prefix: string) {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return `${prefix}-${crypto.randomUUID()}`;
+  }
+  return `${prefix}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function normalizeProject(project: any, index: number): RepoProjectSecrets | null {
+  const name = sanitizeString(project?.name) ?? sanitizeString(project?.label) ?? sanitizeString(project?.id);
+  if (!name) {
+    return null;
+  }
+  const id = sanitizeString(project?.id) ?? `${slugify(name)}-${index}`;
+  return {
+    id,
+    name,
+    ...(sanitizeString(project?.supabaseReadOnlyUrl)
+      ? { supabaseReadOnlyUrl: sanitizeString(project?.supabaseReadOnlyUrl) }
+      : {}),
+    ...(sanitizeString(project?.githubPat) ? { githubPat: sanitizeString(project?.githubPat) } : {}),
+    ...(sanitizeString(project?.openaiKey) ? { openaiKey: sanitizeString(project?.openaiKey) } : {}),
+  };
+}
+
+function normalizeRepo(repo: any, index: number): RepoSecrets | null {
+  const owner = sanitizeString(repo?.owner);
+  const name = sanitizeString(repo?.repo);
+  if (!owner || !name) {
+    return null;
+  }
+  const id = sanitizeString(repo?.id) ?? `${owner.toLowerCase()}/${name.toLowerCase()}`;
+  const projects = Array.isArray(repo?.projects)
+    ? (repo.projects
+        .map((project: any, projectIndex: number) => normalizeProject(project, projectIndex))
+        .filter(Boolean) as RepoProjectSecrets[])
+    : [];
+
+  return {
+    id,
+    owner,
+    repo: name,
+    projects,
+    ...(sanitizeString(repo?.displayName) ? { displayName: sanitizeString(repo?.displayName) } : {}),
+    ...(sanitizeString(repo?.supabaseReadOnlyUrl)
+      ? { supabaseReadOnlyUrl: sanitizeString(repo?.supabaseReadOnlyUrl) }
+      : {}),
+    ...(sanitizeString(repo?.githubPat) ? { githubPat: sanitizeString(repo?.githubPat) } : {}),
+    ...(sanitizeString(repo?.openaiKey) ? { openaiKey: sanitizeString(repo?.openaiKey) } : {}),
+  };
+}
+
+function parseSecrets(raw: string | null): SecretsStore {
+  if (!raw) return EMPTY_STORE;
+  try {
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object") {
+      return EMPTY_STORE;
+    }
+
+    if ("defaults" in parsed || "repos" in parsed) {
+      const defaultsInput = (parsed as Partial<SecretsStore>)?.defaults ?? {};
+      const reposInput = Array.isArray((parsed as Partial<SecretsStore>)?.repos)
+        ? ((parsed as Partial<SecretsStore>).repos as any[])
+        : [];
+
+      const defaults = {
+        ...(sanitizeString((defaultsInput as any)?.githubPat)
+          ? { githubPat: sanitizeString((defaultsInput as any)?.githubPat) }
+          : {}),
+        ...(sanitizeString((defaultsInput as any)?.openaiKey)
+          ? { openaiKey: sanitizeString((defaultsInput as any)?.openaiKey) }
+          : {}),
+        ...(sanitizeString((defaultsInput as any)?.supabaseReadOnlyUrl)
+          ? { supabaseReadOnlyUrl: sanitizeString((defaultsInput as any)?.supabaseReadOnlyUrl) }
+          : {}),
+      };
+
+      const repos = reposInput
+        .map((repo, repoIndex) => normalizeRepo(repo, repoIndex))
+        .filter(Boolean) as RepoSecrets[];
+
+      return { defaults, repos };
+    }
+
+    const defaults: SecretsStore["defaults"] = {};
+    const githubPat = sanitizeString((parsed as any)?.githubPat);
+    const openaiKey = sanitizeString((parsed as any)?.openaiKey);
+    const supabase = sanitizeString((parsed as any)?.supabaseReadOnlyUrl);
+
+    if (githubPat) defaults.githubPat = githubPat;
+    if (openaiKey) defaults.openaiKey = openaiKey;
+    if (supabase) defaults.supabaseReadOnlyUrl = supabase;
+
+    return { defaults, repos: [] };
+  } catch (error) {
+    console.warn("Failed to parse stored secrets", error);
+    return EMPTY_STORE;
+  }
+}
+
+export function readLocalSecrets(): SecretsStore {
+  if (typeof window === "undefined") {
+    return EMPTY_STORE;
+  }
+  const raw = window.localStorage.getItem(LOCAL_SECRETS_STORAGE_KEY);
+  return parseSecrets(raw);
+}
+
+export function useLocalSecrets() {
+  const [store, setStore] = useState<SecretsStore>(() => {
+    if (typeof window === "undefined") {
+      return EMPTY_STORE;
+    }
+    return readLocalSecrets();
+  });
+
+  useEffect(() => {
+    function refresh() {
+      setStore(readLocalSecrets());
+    }
+
+    window.addEventListener("storage", refresh);
+    window.addEventListener(LOCAL_SECRETS_EVENT, refresh);
+
+    return () => {
+      window.removeEventListener("storage", refresh);
+      window.removeEventListener(LOCAL_SECRETS_EVENT, refresh);
+    };
+  }, []);
+
+  return store;
+}
+
+function matchRepo(store: SecretsStore, owner?: string, repo?: string): RepoSecrets | undefined {
+  if (!owner || !repo) return undefined;
+  const normalizedOwner = owner.trim().toLowerCase();
+  const normalizedRepo = repo.trim().toLowerCase();
+  return store.repos.find((entry) =>
+    entry.owner.trim().toLowerCase() === normalizedOwner && entry.repo.trim().toLowerCase() === normalizedRepo,
+  );
+}
+
+export function resolveSecrets(
+  store: SecretsStore,
+  owner?: string,
+  repo?: string,
+  projectId?: string | null,
+): ResolvedSecrets {
+  const defaults = store?.defaults ?? {};
+  let githubPat = sanitizeString(defaults.githubPat);
+  let openaiKey = sanitizeString(defaults.openaiKey);
+  let supabaseReadOnlyUrl = sanitizeString(defaults.supabaseReadOnlyUrl);
+  const sources: ResolvedSecrets["sources"] = {
+    ...(githubPat ? { githubPat: "default" as const } : {}),
+    ...(openaiKey ? { openaiKey: "default" as const } : {}),
+    ...(supabaseReadOnlyUrl ? { supabaseReadOnlyUrl: "default" as const } : {}),
+  };
+
+  const repoEntry = owner && repo ? matchRepo(store, owner, repo) : undefined;
+  let projectEntry: RepoProjectSecrets | undefined;
+
+  if (repoEntry) {
+    if (sanitizeString(repoEntry.githubPat)) {
+      githubPat = sanitizeString(repoEntry.githubPat);
+      sources.githubPat = "repo";
+    }
+    if (sanitizeString(repoEntry.openaiKey)) {
+      openaiKey = sanitizeString(repoEntry.openaiKey);
+      sources.openaiKey = "repo";
+    }
+    if (sanitizeString(repoEntry.supabaseReadOnlyUrl)) {
+      supabaseReadOnlyUrl = sanitizeString(repoEntry.supabaseReadOnlyUrl);
+      sources.supabaseReadOnlyUrl = "repo";
+    }
+    if (projectId) {
+      projectEntry = repoEntry.projects.find((project) => project.id === projectId);
+    }
+    if (!projectEntry && repoEntry.projects.length === 1 && !projectId) {
+      projectEntry = repoEntry.projects[0];
+    }
+    if (projectEntry) {
+      if (sanitizeString(projectEntry.githubPat)) {
+        githubPat = sanitizeString(projectEntry.githubPat);
+        sources.githubPat = "project";
+      }
+      if (sanitizeString(projectEntry.openaiKey)) {
+        openaiKey = sanitizeString(projectEntry.openaiKey);
+        sources.openaiKey = "project";
+      }
+      if (sanitizeString(projectEntry.supabaseReadOnlyUrl)) {
+        supabaseReadOnlyUrl = sanitizeString(projectEntry.supabaseReadOnlyUrl);
+        sources.supabaseReadOnlyUrl = "project";
+      }
+    }
+  }
+
+  return {
+    githubPat,
+    openaiKey,
+    supabaseReadOnlyUrl,
+    sources,
+    repo: repoEntry,
+    project: projectEntry,
+  };
+}
+
+export function useResolvedSecrets(owner?: string, repo?: string, projectId?: string | null) {
+  const store = useLocalSecrets();
+  return useMemo(() => resolveSecrets(store, owner, repo, projectId ?? undefined), [store, owner, repo, projectId]);
+}
+
+export function createRepoEntry(owner: string, repo: string, displayName?: string): RepoSecrets {
+  const trimmedOwner = owner.trim();
+  const trimmedRepo = repo.trim();
+  const id = `${trimmedOwner.toLowerCase()}/${trimmedRepo.toLowerCase()}`;
+  return {
+    id,
+    owner: trimmedOwner,
+    repo: trimmedRepo,
+    displayName: displayName?.trim() || undefined,
+    projects: [],
+  };
+}
+
+export function createProjectEntry(name: string): RepoProjectSecrets {
+  const trimmed = name.trim();
+  return {
+    id: `${slugify(trimmed)}-${randomId("project")}`,
+    name: trimmed,
+  };
+}
+
+export function writeSecretsToStorage(store: SecretsStore) {
+  if (typeof window === "undefined") return;
+  const payload = JSON.stringify(store);
+  window.localStorage.setItem(LOCAL_SECRETS_STORAGE_KEY, payload);
+  window.dispatchEvent(new Event(LOCAL_SECRETS_EVENT));
+}
+
+export function normalizeSecretsForSave(store: SecretsStore): SecretsStore {
+  const defaults = {
+    ...(sanitizeString(store?.defaults?.githubPat)
+      ? { githubPat: sanitizeString(store.defaults.githubPat)! }
+      : {}),
+    ...(sanitizeString(store?.defaults?.openaiKey)
+      ? { openaiKey: sanitizeString(store.defaults.openaiKey)! }
+      : {}),
+    ...(sanitizeString(store?.defaults?.supabaseReadOnlyUrl)
+      ? { supabaseReadOnlyUrl: sanitizeString(store.defaults.supabaseReadOnlyUrl)! }
+      : {}),
+  };
+
+  const repos = (store?.repos ?? [])
+    .map((repo) => {
+      const owner = sanitizeString(repo?.owner);
+      const name = sanitizeString(repo?.repo);
+      if (!owner || !name) {
+        return null;
+      }
+
+      const normalized: RepoSecrets = {
+        id: `${owner.toLowerCase()}/${name.toLowerCase()}`,
+        owner,
+        repo: name,
+        projects: [],
+        ...(sanitizeString(repo?.displayName) ? { displayName: sanitizeString(repo?.displayName) } : {}),
+        ...(sanitizeString(repo?.supabaseReadOnlyUrl)
+          ? { supabaseReadOnlyUrl: sanitizeString(repo?.supabaseReadOnlyUrl) }
+          : {}),
+        ...(sanitizeString(repo?.githubPat) ? { githubPat: sanitizeString(repo?.githubPat) } : {}),
+        ...(sanitizeString(repo?.openaiKey) ? { openaiKey: sanitizeString(repo?.openaiKey) } : {}),
+      };
+
+      normalized.projects = (repo?.projects ?? [])
+        .map((project) => {
+          const name = sanitizeString(project?.name);
+          if (!name) {
+            return null;
+          }
+          const id = sanitizeString(project?.id) ?? `${slugify(name)}-${randomId("project")}`;
+          return {
+            id,
+            name,
+            ...(sanitizeString(project?.supabaseReadOnlyUrl)
+              ? { supabaseReadOnlyUrl: sanitizeString(project?.supabaseReadOnlyUrl) }
+              : {}),
+            ...(sanitizeString(project?.githubPat) ? { githubPat: sanitizeString(project?.githubPat) } : {}),
+            ...(sanitizeString(project?.openaiKey) ? { openaiKey: sanitizeString(project?.openaiKey) } : {}),
+          } as RepoProjectSecrets;
+        })
+        .filter(Boolean) as RepoProjectSecrets[];
+
+      return normalized;
+    })
+    .filter(Boolean) as RepoSecrets[];
+
+  return { defaults, repos };
+}

--- a/lib/wizard-entry-points.ts
+++ b/lib/wizard-entry-points.ts
@@ -1,0 +1,106 @@
+export type WizardEntryTool = {
+  href: string;
+  label: string;
+  description?: string;
+};
+
+export type WizardEntryPoint = {
+  slug: string;
+  label: string;
+  title: string;
+  description: string;
+  bullets: readonly string[];
+  tools?: readonly WizardEntryTool[];
+};
+
+export const WIZARD_ENTRY_POINTS: readonly WizardEntryPoint[] = [
+  {
+    slug: "new-idea",
+    label: "Ideate",
+    title: "New Idea Brainstorming",
+    description:
+      "Open a persistent AI ideation hub that captures every spark, note, and inspiration so nothing gets lost between sessions.",
+    bullets: [
+      "Start a project-linked conversation that keeps your brainstorming history in sync.",
+      "Clip research, voice notes, and quick sketches into a living idea vault.",
+      "Upgrade the flow into a roadmap whenever you are ready to commit.",
+    ],
+    tools: [
+      {
+        href: "/wizard/brainstorm",
+        label: "Launch idea workspace",
+        description: "Open the AI chat that logs every turn and can be promoted into docs/idea-log.md.",
+      },
+    ],
+  },
+  {
+    slug: "concept",
+    label: "Design",
+    title: "Firm Concept, Missing Roadmap",
+    description:
+      "Transform your concept brief into a structured roadmap with generated files, integrations, and connection points.",
+    bullets: [
+      "Import an existing AI chat or upload your concept write-up for instant context.",
+      "Co-create an actionable roadmap and scaffold repo-ready artifacts in one click.",
+      "Wire up Supabase, secrets, and GitHub so your execution stack is ready to ship.",
+    ],
+    tools: [
+      {
+        href: "/wizard/concept/workspace",
+        label: "Open roadmap drafting workspace",
+        description: "Paste your brief or upload a file, generate docs/roadmap.yml, and commit it to the repo.",
+      },
+    ],
+  },
+  {
+    slug: "roadmap-ready",
+    label: "Launch",
+    title: "Roadmap Ready, Pre-Build",
+    description:
+      "Drop in an existing roadmap and let the wizard provision your repo, automations, and context packs automatically.",
+    bullets: [
+      "Upload roadmap docs and sync the structure into docs/roadmap.yml.",
+      "Generate GTM, tech stack, and infra snapshots that stay aligned with the plan.",
+      "Push the new workspace to GitHub with secrets and integrations configured.",
+    ],
+    tools: [
+      {
+        href: "/wizard/roadmap/workspace",
+        label: "Launch provisioning workspace",
+        description:
+          "Upload an existing roadmap.yml, validate it, and scaffold infra-facts, tech stack, and roadmap workflow files.",
+      },
+      {
+        href: "/dashboard?tab=gtm",
+        label: "Open GTM plan workspace",
+        description:
+          "Jump straight to the dashboard GTM tab to capture market, channel, pricing, and metrics notes in docs/gtm-plan.md.",
+      },
+    ],
+  },
+  {
+    slug: "mid-build",
+    label: "Scale",
+    title: "Mid-Project Build",
+    description:
+      "Layer discovery mode on top of your active repo so AI copilots see progress, regressions, and the next best action.",
+    bullets: [
+      "Ingest repo history, Supabase schema, and roadmap status into a unified context pack.",
+      "Surface off-roadmap work automatically so nothing gets lost in the shuffle.",
+      "Hand the full context to your AI teammate or keep coding with richer feedback.",
+    ],
+    tools: [
+      {
+        href: "/wizard/midproject/workspace",
+        label: "Launch mid-project sync",
+        description: "Run status + discover workflows and preview backlog discoveries before opening the dashboard.",
+      },
+      {
+        href: "/wizard/midproject/workspace#context-pack",
+        label: "Export context pack",
+        description:
+          "Bundle roadmap, status, tech stack, backlog, and GTM artifacts into a single JSON for AI copilots.",
+      },
+    ],
+  },
+] as const;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.3.0",
       "dependencies": {
         "jose": "^5.10.0",
+        "micromatch": "^4.0.8",
         "js-yaml": "^4.1.0",
         "jsonwebtoken": "^9.0.2",
         "next": "^14.2.32",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "jose": "^5.10.0",
+    "micromatch": "^4.0.8",
     "js-yaml": "^4.1.0",
     "jsonwebtoken": "^9.0.2",
     "next": "^14.2.32",

--- a/types/micromatch.d.ts
+++ b/types/micromatch.d.ts
@@ -1,0 +1,15 @@
+declare module "micromatch" {
+  export interface MicromatchOptions {
+    dot?: boolean;
+    nocase?: boolean;
+    nobrace?: boolean;
+    noglobstar?: boolean;
+    [key: string]: unknown;
+  }
+
+  export default function micromatch(
+    list: string[] | string,
+    patterns: string | string[],
+    options?: MicromatchOptions,
+  ): string[];
+}


### PR DESCRIPTION
## Summary
- add shared helpers to normalize project keys and generate project-aware artifact paths
- extend the concept drafting workspace with saved repo/project selectors and target path messaging
- update the roadmap provisioning workspace to surface linked repos/projects and scaffold the correct project-specific files

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de7d44be18832d996ca1abd0348a3b