### PR TITLE
Fix undefined probe headers reference in run API route

### DIFF
--- a/app/api/run/route.ts
+++ b/app/api/run/route.ts
@@ -120,9 +120,6 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: "missing owner/repo" }, { status: 400 });
     }
 
-    const overrideHeaders = parseProbeHeaders(probeHeaders);
-    const probeHeadersFinal: ProbeHeaders = { ...ENV_PROBE_HEADERS, ...(overrideHeaders || {}) };
-
     // Load roadmap spec
     const roadmapPath = projectAwarePath("docs/roadmap.yml", projectKey);
     const rmRaw = await getFileRaw(owner, repo, roadmapPath, branch, token);


### PR DESCRIPTION
## Summary
- remove unused probe headers parsing that referenced an undefined variable
- rely on the existing combined probe headers when running roadmap checks

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68e1b1716b48832d94f287dfa04ca221