### PR TITLE
Enable wizard handoffs between stages

### DIFF
--- a/app/api/wizard/handoff/route.ts
+++ b/app/api/wizard/handoff/route.ts
@@ -1,0 +1,56 @@
+import { NextResponse } from "next/server";
+import fs from "fs/promises";
+import path from "path";
+
+function formatBytes(bytes: number) {
+  if (!Number.isFinite(bytes) || bytes <= 0) {
+    return "0 B";
+  }
+  const units = ["B", "KB", "MB", "GB"];
+  let value = bytes;
+  let unitIndex = 0;
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024;
+    unitIndex += 1;
+  }
+  const precision = value < 10 && unitIndex > 0 ? 1 : 0;
+  return `${value.toFixed(precision)} ${units[unitIndex]}`;
+}
+
+export async function GET(request: Request) {
+  try {
+    const url = new URL(request.url);
+    const pathParam = url.searchParams.get("path");
+    if (!pathParam) {
+      return NextResponse.json({ error: "Missing path" }, { status: 400 });
+    }
+
+    const normalized = path.posix.normalize(pathParam.replace(/\\/g, "/"));
+    if (!normalized || normalized === "docs" || !normalized.startsWith("docs/")) {
+      return NextResponse.json({ error: "Only docs/* paths can be shared" }, { status: 400 });
+    }
+
+    const filePath = path.join(process.cwd(), normalized);
+    const docsDir = path.join(process.cwd(), "docs");
+    if (!filePath.startsWith(docsDir)) {
+      return NextResponse.json({ error: "Invalid path" }, { status: 400 });
+    }
+
+    const stats = await fs.stat(filePath).catch(() => null);
+    if (!stats || !stats.isFile()) {
+      return NextResponse.json({ error: "File not found" }, { status: 404 });
+    }
+
+    const content = await fs.readFile(filePath, "utf8");
+    return NextResponse.json({
+      ok: true,
+      path: normalized,
+      name: path.basename(filePath),
+      size: stats.size,
+      sizeLabel: formatBytes(stats.size),
+      content,
+    });
+  } catch (error: any) {
+    return NextResponse.json({ error: error?.message ?? "Failed to load shared file" }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## Summary
- add an API endpoint that reads docs/* files so wizard stages can share outputs
- persist ideation exports and surface a continue-to-concept action in the brainstorm workspace
- allow the concept and roadmap workspaces to import prior-stage files or generated content with inline callouts and status messaging

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e1cc0b4bf0832da0b4489c007c01c9