### PR TITLE
Enable GitHub-backed wizard handoffs

### DIFF
--- a/app/api/brainstorm/promote/route.ts
+++ b/app/api/brainstorm/promote/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
-import fs from "fs/promises";
-import path from "path";
+
+import { describeProjectFile, normalizeProjectKey, projectAwarePath } from "@/lib/project-paths";
+import { getFileRaw, putFile } from "@/lib/github";
 
 type ClientMessage = {
   role: "user" | "assistant";
@@ -10,6 +11,11 @@ type ClientMessage = {
 type PromoteRequestBody = {
   conversationId?: string;
   messages?: ClientMessage[];
+  owner?: string;
+  repo?: string;
+  branch?: string;
+  project?: string | null;
+  openAsPr?: boolean;
 };
 
 function normalizeMessages(messages?: ClientMessage[]): ClientMessage[] {
@@ -40,6 +46,23 @@ function formatTranscript(messages: ClientMessage[]): string {
     .join("\n");
 }
 
+function appendIdeaEntry(
+  existing: string | null,
+  transcript: string,
+  timestamp: string,
+  conversationId?: string | null,
+) {
+  const headerParts = [
+    `## Session promoted on ${timestamp}`,
+    conversationId ? `Session ID: ${conversationId}` : undefined,
+    "",
+  ].filter(Boolean);
+
+  const base = existing ? `${existing.trimEnd()}\n\n` : "# Idea Log\n\n";
+  const entry = `${headerParts.join("\n")}\n${transcript.trim()}\n`;
+  return `${base}${entry.trimEnd()}\n\n`;
+}
+
 export async function POST(req: Request) {
   let body: PromoteRequestBody;
 
@@ -55,31 +78,61 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: "No messages to export" }, { status: 400 });
   }
 
+  const owner = body.owner?.trim();
+  const repo = body.repo?.trim();
+  const branch = body.branch?.trim() || "main";
+  const project = body.project?.trim();
+  const openAsPr = Boolean(body.openAsPr);
+
+  if (!owner || !repo) {
+    return NextResponse.json({ error: "Missing owner or repo" }, { status: 400 });
+  }
+
+  const projectKey = normalizeProjectKey(project);
+  const basePath = "docs/idea-log.md";
+  const targetPath = projectAwarePath(basePath, projectKey);
+  const label = describeProjectFile(basePath, projectKey);
+
+  const transcript = formatTranscript(messages);
   const conversationId = body.conversationId?.trim();
   const timestamp = new Date().toISOString();
 
-  const docsDir = path.join(process.cwd(), "docs");
-  await fs.mkdir(docsDir, { recursive: true });
-  const ideaLogPath = path.join(docsDir, "idea-log.md");
+  const token = req.headers.get("x-github-pat") ?? undefined;
 
-  let content = "";
+  let existing: string | null = null;
   try {
-    await fs.access(ideaLogPath);
-  } catch {
-    content += "# Idea Log\n\n";
+    existing = await getFileRaw(owner, repo, targetPath, branch, token);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return NextResponse.json({ error: "Failed to load existing idea log", detail: message }, { status: 500 });
   }
 
-  const sessionHeaderParts = [
-    `## Session promoted on ${timestamp}`,
-    conversationId ? `Session ID: ${conversationId}` : undefined,
-    "",
-  ].filter(Boolean);
+  const content = appendIdeaEntry(existing, transcript, timestamp, conversationId);
+  const commitMessage = conversationId
+    ? `Add idea log entry for ${conversationId}`
+    : "Add idea log entry";
 
-  const transcript = formatTranscript(messages);
-
-  content += `${sessionHeaderParts.join("\n")}\n${transcript}\n\n`;
-
-  await fs.appendFile(ideaLogPath, content, "utf8");
-
-  return NextResponse.json({ ok: true, path: "docs/idea-log.md" });
+  try {
+    const result = await putFile(owner, repo, targetPath, content, branch, commitMessage, {
+      token,
+      asPR: openAsPr,
+    });
+    const resolvedBranch = typeof result.branch === "string" ? result.branch : branch;
+    const pullRequest = result.pullRequest;
+    return NextResponse.json({
+      ok: true,
+      path: basePath,
+      label,
+      owner,
+      repo,
+      branch,
+      promotedBranch: resolvedBranch,
+      project: projectKey ?? null,
+      prUrl: pullRequest?.html_url ?? pullRequest?.url,
+      pullRequestNumber: pullRequest?.number,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return NextResponse.json({ error: "Failed to write idea log", detail: message }, { status: 500 });
+  }
 }

--- a/app/api/wizard/handoff/route.ts
+++ b/app/api/wizard/handoff/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from "next/server";
-import fs from "fs/promises";
 import path from "path";
+
+import { getFileRaw } from "@/lib/github";
+import { describeProjectFile, normalizeProjectKey, projectAwarePath } from "@/lib/project-paths";
 
 function formatBytes(bytes: number) {
   if (!Number.isFinite(bytes) || bytes <= 0) {
@@ -21,8 +23,13 @@ export async function GET(request: Request) {
   try {
     const url = new URL(request.url);
     const pathParam = url.searchParams.get("path");
-    if (!pathParam) {
-      return NextResponse.json({ error: "Missing path" }, { status: 400 });
+    const owner = url.searchParams.get("owner");
+    const repo = url.searchParams.get("repo");
+    const branch = url.searchParams.get("branch") ?? "main";
+    const projectParam = url.searchParams.get("project");
+
+    if (!pathParam || !owner || !repo) {
+      return NextResponse.json({ error: "Missing path or repository context" }, { status: 400 });
     }
 
     const normalized = path.posix.normalize(pathParam.replace(/\\/g, "/"));
@@ -30,24 +37,31 @@ export async function GET(request: Request) {
       return NextResponse.json({ error: "Only docs/* paths can be shared" }, { status: 400 });
     }
 
-    const filePath = path.join(process.cwd(), normalized);
-    const docsDir = path.join(process.cwd(), "docs");
-    if (!filePath.startsWith(docsDir)) {
+    if (normalized.includes("..")) {
       return NextResponse.json({ error: "Invalid path" }, { status: 400 });
     }
 
-    const stats = await fs.stat(filePath).catch(() => null);
-    if (!stats || !stats.isFile()) {
+    const projectKey = normalizeProjectKey(projectParam);
+    const label = describeProjectFile(normalized, projectKey);
+    const targetPath = normalized.startsWith("docs/projects/")
+      ? normalized
+      : projectAwarePath(normalized, projectKey);
+
+    const token = request.headers.get("x-github-pat") ?? undefined;
+    const content = await getFileRaw(owner, repo, targetPath, branch, token);
+    if (content === null) {
       return NextResponse.json({ error: "File not found" }, { status: 404 });
     }
 
-    const content = await fs.readFile(filePath, "utf8");
+    const size = new TextEncoder().encode(content).length;
+
     return NextResponse.json({
       ok: true,
       path: normalized,
-      name: path.basename(filePath),
-      size: stats.size,
-      sizeLabel: formatBytes(stats.size),
+      label,
+      name: path.basename(targetPath),
+      size,
+      sizeLabel: formatBytes(size),
       content,
     });
   } catch (error: any) {

--- a/app/wizard/concept/workspace/page.tsx
+++ b/app/wizard/concept/workspace/page.tsx
@@ -40,6 +40,13 @@ type HandoffHint = {
   path: string;
   label?: string;
   content?: string;
+  owner?: string;
+  repo?: string;
+  branch?: string;
+  promotedBranch?: string;
+  project?: string | null;
+  prUrl?: string;
+  pullRequestNumber?: number;
 };
 
 const CONCEPT_HANDOFF_KEY = "wizard:handoff:concept";
@@ -155,6 +162,7 @@ function ConceptWizardPageInner() {
   const repoEntries = secretsStore.repos;
   const [selectedRepoId, setSelectedRepoId] = useState<string>(ADD_NEW_REPO_OPTION);
   const [selectedProjectOption, setSelectedProjectOption] = useState<string>("");
+  const [initialContextApplied, setInitialContextApplied] = useState(false);
   const repoSlug = useMemo(() => {
     const ownerSlug = owner.trim().toLowerCase();
     const repoSlugValue = repo.trim().toLowerCase();
@@ -266,14 +274,62 @@ function ConceptWizardPageInner() {
       const storedRaw = window.localStorage.getItem(CONCEPT_HANDOFF_KEY);
       const stored = storedRaw ? (JSON.parse(storedRaw) as HandoffHint & { createdAt?: number }) : null;
 
+      const applyContext = (hint: HandoffHint | null) => {
+        if (!hint || initialContextApplied) {
+          return;
+        }
+        let updated = false;
+        if (hint.owner && !owner) {
+          setOwner(hint.owner);
+          updated = true;
+        }
+        if (hint.repo && !repo) {
+          setRepo(hint.repo);
+          updated = true;
+        }
+        if (hint.branch && (!branch || branch === "main")) {
+          setBranch(hint.branch);
+          updated = true;
+        }
+        if (hint.project && !project) {
+          setProject(hint.project);
+          updated = true;
+        }
+        if (updated || hint.owner || hint.repo || hint.branch || hint.project) {
+          setInitialContextApplied(true);
+        }
+      };
+
+      const hydrateHint = (hint: HandoffHint | null) => {
+        if (!hint) {
+          return null;
+        }
+        return {
+          path: hint.path,
+          label: hint.label,
+          content: hint.content,
+          owner: hint.owner,
+          repo: hint.repo,
+          branch: hint.branch,
+          promotedBranch: hint.promotedBranch,
+          project: hint.project ?? null,
+          prUrl: hint.prUrl,
+          pullRequestNumber: hint.pullRequestNumber,
+        } satisfies HandoffHint;
+      };
+
       if (handoffParam) {
         if (stored && stored.path === handoffParam) {
-          setHandoffHint({ path: stored.path, label: stored.label, content: stored.content });
+          const hydrated = hydrateHint(stored);
+          setHandoffHint(hydrated);
+          applyContext(hydrated);
         } else {
           setHandoffHint({ path: handoffParam });
         }
       } else if (stored?.path) {
-        setHandoffHint({ path: stored.path, label: stored.label, content: stored.content });
+        const hydrated = hydrateHint(stored);
+        setHandoffHint(hydrated);
+        applyContext(hydrated);
       } else {
         setHandoffHint(null);
       }
@@ -283,7 +339,7 @@ function ConceptWizardPageInner() {
         setHandoffHint({ path: handoffParam });
       }
     }
-  }, [handoffParam]);
+  }, [handoffParam, branch, owner, project, repo, initialContextApplied]);
 
   useEffect(() => {
     if (typeof window === "undefined") {
@@ -297,10 +353,14 @@ function ConceptWizardPageInner() {
     }
 
     const label = describeProjectFile("docs/roadmap.yml", projectKey);
-    const payload = {
+    const payload: HandoffHint & { createdAt: number } = {
       path: label,
       label,
       content: trimmed,
+      owner,
+      repo,
+      branch,
+      project: projectKey ?? null,
       createdAt: Date.now(),
     };
 
@@ -309,7 +369,7 @@ function ConceptWizardPageInner() {
     } catch (err) {
       console.error("Failed to persist roadmap handoff", err);
     }
-  }, [roadmap, projectKey]);
+  }, [roadmap, projectKey, owner, repo, branch]);
 
   const canGenerate = Boolean(!isGenerating && combinedPrompt);
   const targetPath = describeProjectFile("docs/roadmap.yml", projectKey);
@@ -419,7 +479,31 @@ function ConceptWizardPageInner() {
       let sizeLabel = "";
 
       if (!content) {
-        const response = await fetch(`/api/wizard/handoff?path=${encodeURIComponent(handoffHint.path)}`);
+        const fetchOwner = handoffHint.owner || owner;
+        const fetchRepo = handoffHint.repo || repo;
+        if (!fetchOwner || !fetchRepo) {
+          setHandoffError("Provide owner and repo before importing the shared file.");
+          return;
+        }
+
+        const params = new URLSearchParams({ path: handoffHint.path });
+        params.set("owner", fetchOwner);
+        params.set("repo", fetchRepo);
+        const fetchBranch = handoffHint.promotedBranch || handoffHint.branch || branch || "main";
+        if (fetchBranch) {
+          params.set("branch", fetchBranch);
+        }
+        const fetchProject = handoffHint.project ?? (project || "");
+        if (fetchProject) {
+          params.set("project", fetchProject);
+        }
+
+        const headers: HeadersInit = {};
+        if (secrets.githubPat) {
+          headers["x-github-pat"] = secrets.githubPat;
+        }
+
+        const response = await fetch(`/api/wizard/handoff?${params.toString()}`, { headers });
         const payload = await response.json().catch(() => ({}));
 
         if (!response.ok || !payload?.ok) {
@@ -429,13 +513,22 @@ function ConceptWizardPageInner() {
         }
 
         content = typeof payload.content === "string" ? payload.content : "";
-        name = typeof payload.name === "string" ? payload.name : name;
+        const payloadLabel = typeof payload.label === "string" ? payload.label : undefined;
+        name = payloadLabel ?? (typeof payload.name === "string" ? payload.name : name);
         sizeLabel = typeof payload.sizeLabel === "string" ? payload.sizeLabel : sizeLabel;
         const normalizedPath = typeof payload.path === "string" ? payload.path : handoffHint.path;
+        const baseBranch = handoffHint.branch || branch || "main";
+        const projectForHint = (handoffHint.project ?? fetchProject) || null;
         const updatedHint: HandoffHint = {
+          ...handoffHint,
           path: normalizedPath,
-          label: name,
+          label: payloadLabel ?? name,
           content,
+          owner: fetchOwner,
+          repo: fetchRepo,
+          branch: baseBranch,
+          promotedBranch: fetchBranch,
+          project: projectForHint,
         };
         setHandoffHint(updatedHint);
         if (typeof window !== "undefined") {


### PR DESCRIPTION
## Summary
- push brainstorm promotions to project-aware GitHub paths and return commit/PR metadata
- update the idea workspace to capture repo context, promote via commit or PR, and persist handoff metadata for downstream steps
- refactor wizard handoff loading plus concept/roadmap workspaces to pull shared docs from GitHub with shared repo/project context

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e449f7e930832d919077229153bbbe