### PR TITLE
Normalize concept handoff promoted branch handling

### DIFF
--- a/app/wizard/concept/workspace/page.tsx
+++ b/app/wizard/concept/workspace/page.tsx
@@ -17,7 +17,12 @@ import { describeProjectFile, normalizeProjectKey } from "@/lib/project-paths";
 import { useLocalSecrets, useResolvedSecrets } from "@/lib/use-local-secrets";
 
 type ErrorState = { title: string; detail?: string } | null;
-type SuccessState = { message: string; prUrl?: string; handoffPath?: string } | null;
+type SuccessState = {
+  message: string;
+  prUrl?: string;
+  handoffPath?: string;
+  promotedBranch?: string;
+} | null;
 
 type GenerateResponse = { roadmap: string };
 
@@ -153,6 +158,7 @@ function ConceptWizardPageInner() {
   const [success, setSuccess] = useState<SuccessState>(null);
   const [openAsPr, setOpenAsPr] = useState(false);
   const [isCommitting, setIsCommitting] = useState(false);
+  const [promotedBranch, setPromotedBranch] = useState<string | null>(null);
   const previewRef = useRef<HTMLPreElement | null>(null);
   const editorRef = useRef<HTMLTextAreaElement | null>(null);
   const secretsStore = useLocalSecrets();
@@ -287,8 +293,9 @@ function ConceptWizardPageInner() {
           setRepo(hint.repo);
           updated = true;
         }
-        if (hint.branch && (!branch || branch === "main")) {
-          setBranch(hint.branch);
+        const preferredBranch = hint.promotedBranch?.trim() || hint.branch?.trim();
+        if (preferredBranch && (!branch || branch === "main")) {
+          setBranch(preferredBranch);
           updated = true;
         }
         if (hint.project && !project) {
@@ -322,22 +329,29 @@ function ConceptWizardPageInner() {
         if (stored && stored.path === handoffParam) {
           const hydrated = hydrateHint(stored);
           setHandoffHint(hydrated);
+          const nextPromoted = hydrated?.promotedBranch?.trim() ?? null;
+          setPromotedBranch((current) => (current === nextPromoted ? current : nextPromoted));
           applyContext(hydrated);
         } else {
           setHandoffHint({ path: handoffParam });
+          setPromotedBranch((current) => (current === null ? current : null));
         }
       } else if (stored?.path) {
         const hydrated = hydrateHint(stored);
         setHandoffHint(hydrated);
+        const nextPromoted = hydrated?.promotedBranch?.trim() ?? null;
+        setPromotedBranch((current) => (current === nextPromoted ? current : nextPromoted));
         applyContext(hydrated);
       } else {
         setHandoffHint(null);
+        setPromotedBranch((current) => (current === null ? current : null));
       }
     } catch (err) {
       console.error("Failed to read concept handoff", err);
       if (handoffParam) {
         setHandoffHint({ path: handoffParam });
       }
+      setPromotedBranch((current) => (current === null ? current : null));
     }
   }, [handoffParam, branch, owner, project, repo, initialContextApplied]);
 
@@ -353,27 +367,63 @@ function ConceptWizardPageInner() {
     }
 
     const label = describeProjectFile("docs/roadmap.yml", projectKey);
-    const payload: HandoffHint & { createdAt: number } = {
+    const trimmedOwner = owner.trim();
+    const trimmedRepo = repo.trim();
+    const trimmedBranch = branch.trim();
+    const trimmedPromoted = promotedBranch?.trim() ?? null;
+
+    const payload = {
       path: label,
       label,
       content: trimmed,
-      owner,
-      repo,
-      branch,
+      ...(trimmedOwner ? { owner: trimmedOwner } : {}),
+      ...(trimmedRepo ? { repo: trimmedRepo } : {}),
+      ...(trimmedBranch ? { branch: trimmedBranch } : {}),
       project: projectKey ?? null,
+      ...(trimmedPromoted ? { promotedBranch: trimmedPromoted } : {}),
       createdAt: Date.now(),
-    };
+    } satisfies HandoffHint & { createdAt: number };
 
     try {
       window.localStorage.setItem(ROADMAP_HANDOFF_KEY, JSON.stringify(payload));
     } catch (err) {
       console.error("Failed to persist roadmap handoff", err);
     }
-  }, [roadmap, projectKey, owner, repo, branch]);
+  }, [roadmap, projectKey, owner, repo, branch, promotedBranch]);
 
   const canGenerate = Boolean(!isGenerating && combinedPrompt);
   const targetPath = describeProjectFile("docs/roadmap.yml", projectKey);
   const canCommit = Boolean(!isCommitting && roadmap.trim() && owner && repo && branch);
+  const roadmapLinkHref = useMemo(() => {
+    if (!success?.handoffPath) {
+      return null;
+    }
+
+    const params = new URLSearchParams();
+    params.set("handoff", success.handoffPath);
+
+    const trimmedOwner = owner.trim();
+    if (trimmedOwner) {
+      params.set("owner", trimmedOwner);
+    }
+
+    const trimmedRepo = repo.trim();
+    if (trimmedRepo) {
+      params.set("repo", trimmedRepo);
+    }
+
+    const branchSource = success.promotedBranch ?? promotedBranch ?? branch;
+    const trimmedBranch = branchSource ? branchSource.trim() : "";
+    if (trimmedBranch) {
+      params.set("branch", trimmedBranch);
+    }
+
+    if (projectKey) {
+      params.set("project", projectKey);
+    }
+
+    return `/wizard/roadmap/workspace?${params.toString()}`;
+  }, [success, owner, repo, branch, promotedBranch, projectKey]);
 
   async function onGenerate(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -489,7 +539,8 @@ function ConceptWizardPageInner() {
         const params = new URLSearchParams({ path: handoffHint.path });
         params.set("owner", fetchOwner);
         params.set("repo", fetchRepo);
-        const fetchBranch = handoffHint.promotedBranch || handoffHint.branch || branch || "main";
+        const fetchBranchSource = handoffHint.promotedBranch || handoffHint.branch || branch || "main";
+        const fetchBranch = fetchBranchSource.trim();
         if (fetchBranch) {
           params.set("branch", fetchBranch);
         }
@@ -531,6 +582,8 @@ function ConceptWizardPageInner() {
           project: projectForHint,
         };
         setHandoffHint(updatedHint);
+        const nextPromoted = updatedHint.promotedBranch?.trim() ?? null;
+        setPromotedBranch((current) => (current === nextPromoted ? current : nextPromoted));
         if (typeof window !== "undefined") {
           const storedPayload = { ...updatedHint, createdAt: Date.now() };
           window.localStorage.setItem(CONCEPT_HANDOFF_KEY, JSON.stringify(storedPayload));
@@ -595,6 +648,10 @@ function ConceptWizardPageInner() {
 
       if (detail.ok) {
         const committedPath = typeof detail.path === "string" ? detail.path : targetPath;
+        const fallbackBranch = branch.trim() || "main";
+        const resolvedBranch =
+          (typeof detail.branch === "string" && detail.branch.trim()) || fallbackBranch;
+        setPromotedBranch(resolvedBranch);
         if (openAsPr) {
           if (detail.prUrl) {
             const label = detail.pullRequestNumber ? `PR #${detail.pullRequestNumber}` : "Pull request";
@@ -602,16 +659,21 @@ function ConceptWizardPageInner() {
               message: `${label} opened for ${committedPath}.`,
               prUrl: detail.prUrl,
               handoffPath: committedPath,
+              promotedBranch: resolvedBranch,
             });
           } else {
             setSuccess({
               message: `Pull request opened for ${committedPath}. Check GitHub to review and merge.`,
               handoffPath: committedPath,
+              promotedBranch: resolvedBranch,
             });
           }
         } else {
-          const targetBranch = detail.branch ?? branch;
-          setSuccess({ message: `${committedPath} committed to ${targetBranch}.`, handoffPath: committedPath });
+          setSuccess({
+            message: `${committedPath} committed to ${resolvedBranch}.`,
+            handoffPath: committedPath,
+            promotedBranch: resolvedBranch,
+          });
         }
       } else {
         setError({ title: detail?.error ?? "Unexpected response", detail: detail?.detail });
@@ -756,9 +818,9 @@ function ConceptWizardPageInner() {
                   <span aria-hidden="true">↗</span>
                 </a>
               )}
-              {success.handoffPath && (
+              {roadmapLinkHref && (
                 <Link
-                  href={`/wizard/roadmap/workspace?handoff=${encodeURIComponent(success.handoffPath)}`}
+                  href={roadmapLinkHref}
                   className="tw-inline-flex tw-items-center tw-gap-2 tw-rounded-full tw-border tw-border-emerald-400 tw-bg-emerald-500/20 tw-px-3 tw-py-1.5 tw-text-xs tw-font-semibold tw-uppercase tw-tracking-wide tw-text-emerald-100 hover:tw-border-emerald-300 hover:tw-text-white"
                 >
                   Continue to provisioning workspace

--- a/app/wizard/roadmap/workspace/page.tsx
+++ b/app/wizard/roadmap/workspace/page.tsx
@@ -123,7 +123,11 @@ function RoadmapProvisionerInner() {
           setRepo(hint.repo);
           updated = true;
         }
-        if (hint.branch && (!branch || branch === "main")) {
+        const promoted = hint.promotedBranch?.trim();
+        if (promoted && (!branch || branch === "main")) {
+          setBranch(promoted);
+          updated = true;
+        } else if (hint.branch && (!branch || branch === "main")) {
           setBranch(hint.branch);
           updated = true;
         }
@@ -332,7 +336,8 @@ function RoadmapProvisionerInner() {
         const params = new URLSearchParams({ path: handoffHint.path });
         params.set("owner", fetchOwner);
         params.set("repo", fetchRepo);
-        const fetchBranch = handoffHint.promotedBranch || handoffHint.branch || branch || "main";
+        const fetchBranchSource = handoffHint.promotedBranch || handoffHint.branch || branch || "main";
+        const fetchBranch = fetchBranchSource.trim();
         if (fetchBranch) {
           params.set("branch", fetchBranch);
         }


### PR DESCRIPTION
## Summary
- prefer the promoted branch when applying concept handoff context
- hydrate promoted branch state from stored handoffs and trim persisted payload values

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e47217bb68832db40bdd9e937b0266