### PR TITLE
Add mid-project workspace CTA

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2410,6 +2410,16 @@ function DashboardPage() {
     }
     return `/new?${params.toString()}`;
   }, [activeRepo]);
+  const midProjectHref = useMemo(() => {
+    if (!activeRepo) return "/wizard/midproject/workspace";
+    const params = new URLSearchParams();
+    params.set("owner", activeRepo.owner);
+    params.set("repo", activeRepo.repo);
+    if (activeRepo.project) {
+      params.set("project", activeRepo.project);
+    }
+    return `/wizard/midproject/workspace?${params.toString()}`;
+  }, [activeRepo]);
 
   useEffect(() => {
     if (!initialized) return;
@@ -2589,6 +2599,9 @@ function DashboardPage() {
                   </code>
                   <a className="project-wizard" href={wizardHref} target="_blank" rel="noreferrer">
                     Create setup PR ↗
+                  </a>
+                  <a className="project-wizard" href={midProjectHref} target="_blank" rel="noreferrer">
+                    Open mid-project workspace ↗
                   </a>
                   <a
                     href={`/api/status/${activeRepo.owner}/${activeRepo.repo}${activeRepo.project ? `?project=${activeRepo.project}` : ""}`}


### PR DESCRIPTION
## Summary
- derive a mid-project workspace link based on the active repository and project slug
- expose the workspace as an additional call-to-action in the project repo toolbar

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e590e150b8832d983ac584bf2aaa0c